### PR TITLE
feat:파일 업로드 기능 추가 및 S3 유틸 기능 추가-#9

### DIFF
--- a/tradelink/build.gradle
+++ b/tradelink/build.gradle
@@ -54,6 +54,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	//S3
+	implementation platform('software.amazon.awssdk:bom:2.27.21')
+	implementation 'software.amazon.awssdk:s3'
 }
 
 tasks.named('test') {

--- a/tradelink/src/main/java/site/tradelink/tradelink/comment/entity/Comment.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/comment/entity/Comment.java
@@ -1,0 +1,29 @@
+package site.tradelink.tradelink.comment.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import site.tradelink.tradelink.common.entity.BaseEntity;
+import site.tradelink.tradelink.oauth2.entity.Member;
+import site.tradelink.tradelink.post.entity.Post;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Comment extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column (name = "comment_seq")
+    private Long seq;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_seq")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_seq")
+    private Post post;
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/comment/repository/CommentRepository.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/comment/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package site.tradelink.tradelink.comment.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.tradelink.tradelink.comment.entity.Comment;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/comment/response/CommentDto.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/comment/response/CommentDto.java
@@ -1,0 +1,25 @@
+package site.tradelink.tradelink.comment.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.Setter;
+import site.tradelink.tradelink.comment.entity.Comment;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class CommentDto {
+    private Long seq;
+    private String content;
+    private String name;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일 HH시 mm분 ss초", timezone = "Asia/Seoul")
+    private LocalDateTime createTime;
+
+    public CommentDto(Comment comment) {
+        this.seq = comment.getSeq();
+        this.content = comment.getContent();
+        this.name = comment.getMember().getMemberName();
+        this.createTime = comment.getCreateTime();
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/common/converter/BooleanToYnConverter.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/common/converter/BooleanToYnConverter.java
@@ -1,0 +1,30 @@
+package site.tradelink.tradelink.common.converter;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class BooleanToYnConverter implements AttributeConverter<Boolean, String> {
+
+    /**
+     * Boolean 값을 Y 또는 N 으로 컨버트
+     *
+     * @param attribute  boolean 값
+     * @return String // true 인 경우 Y 또는 false 인 경우 N
+     */
+    @Override
+    public String convertToDatabaseColumn(Boolean attribute) {
+        return (attribute != null && attribute) ? "Y" : "N";
+    }
+
+    /**
+     * Y 또는 N 을 Boolean 으로 컨버트
+     *
+     * @param dbData  String // Y 또는 N
+     * @return Boolean // 대, 소문자를 구분짓지 않고 Y 인 경우 true, N 인 경우 false
+     */
+    @Override
+    public Boolean convertToEntityAttribute(String dbData) {
+        return "Y".equalsIgnoreCase(dbData);
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/common/entity/BaseEntity.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/common/entity/BaseEntity.java
@@ -1,0 +1,24 @@
+package site.tradelink.tradelink.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createTime;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedTime;
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/likePost/entity/LikePost.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/likePost/entity/LikePost.java
@@ -1,0 +1,26 @@
+package site.tradelink.tradelink.likePost.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import site.tradelink.tradelink.oauth2.entity.Member;
+import site.tradelink.tradelink.post.entity.Post;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class LikePost {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "like_post_seq")
+    private Long seq;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_seq")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_seq")
+    private Post post;
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/oauth2/entity/Member.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/oauth2/entity/Member.java
@@ -7,9 +7,13 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Entity
 @Getter
+@Builder
 @NoArgsConstructor (access = AccessLevel.PROTECTED)
+@AllArgsConstructor (access = AccessLevel.PRIVATE)
 public class Member {
+
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column (name = "member_seq")
     private Long seq;
 
     @Column(unique = true, nullable = false)

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/config/NcpS3Config.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/config/NcpS3Config.java
@@ -1,0 +1,35 @@
+package site.tradelink.tradelink.post.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.net.URI;
+
+@Configuration
+public class NcpS3Config {
+
+    @Value("${cloud.ncp.s3.endpoint}")
+    private String endpoint;
+
+    @Value("${cloud.ncp.s3.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.ncp.s3.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .endpointOverride(URI.create(endpoint))
+                .region(Region.of("kr-standard"))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)
+                ))
+                .build();
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/entity/Post.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/entity/Post.java
@@ -1,0 +1,31 @@
+package site.tradelink.tradelink.post.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import site.tradelink.tradelink.common.entity.BaseEntity;
+import site.tradelink.tradelink.oauth2.entity.Member;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class Post extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column (name = "post_seq")
+    private Long seq;
+
+    private String title;
+
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_seq")
+    private Member member;
+
+    public void change(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/entity/UploadFile.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/entity/UploadFile.java
@@ -1,0 +1,27 @@
+package site.tradelink.tradelink.post.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import site.tradelink.tradelink.common.entity.BaseEntity;
+
+@Entity
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UploadFile extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "uploadFile_seq")
+    private Long seq;
+
+    private String originalFileName;
+
+    private String saveFileName;
+
+    private String url;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_seq")
+    private Post post;
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/repository/PostRepository.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/repository/PostRepository.java
@@ -1,0 +1,10 @@
+package site.tradelink.tradelink.post.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.tradelink.tradelink.post.entity.Post;
+
+import java.util.List;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+    List<Post> findAllWithUploadFiles();
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/repository/file/UploadFileRepository.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/repository/file/UploadFileRepository.java
@@ -1,0 +1,7 @@
+package site.tradelink.tradelink.post.repository.file;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.tradelink.tradelink.post.entity.UploadFile;
+
+public interface UploadFileRepository extends JpaRepository<UploadFile, Long> {
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/response/PostDto.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/response/PostDto.java
@@ -1,0 +1,47 @@
+package site.tradelink.tradelink.post.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.Setter;
+import site.tradelink.tradelink.comment.entity.Comment;
+import site.tradelink.tradelink.comment.response.CommentDto;
+import site.tradelink.tradelink.post.entity.Post;
+import site.tradelink.tradelink.post.entity.UploadFile;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+public class PostDto {
+    private Long seq;
+    private String title;
+    private String content;
+    private List<CommentDto> comments;
+    private List<UploadFileDto> uploadFiles;
+    private String name;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy년 MM월 dd일 HH시 mm분 ss초", timezone = "Asia/Seoul")
+    private LocalDateTime createTime;
+
+    /**
+     * 1. LazyInitializationException 주의
+     * 2. N+1 문제 주의
+     */
+    public PostDto(Post post, List<Comment> comments, List<UploadFile> uploadFiles) {
+        this.seq = post.getSeq();
+        this.title = post.getTitle();
+        this.content = post.getContent();
+        this.comments = comments == null ? new ArrayList<>() :
+                comments.stream()
+                        .map(CommentDto::new)
+                        .collect(Collectors.toList());
+        this.uploadFiles = uploadFiles == null ? new ArrayList<>() :
+                uploadFiles.stream()
+                        .map(UploadFileDto::new)
+                        .collect(Collectors.toList());
+        this.name = post.getMember().getMemberName();
+        this.createTime = post.getCreateTime();
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/response/UploadFileDto.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/response/UploadFileDto.java
@@ -1,0 +1,19 @@
+package site.tradelink.tradelink.post.response;
+
+import lombok.Getter;
+import lombok.Setter;
+import site.tradelink.tradelink.post.entity.UploadFile;
+
+@Getter
+@Setter
+public class UploadFileDto {
+    private Long seq;
+    private String originalFileName;
+    private String savedFileName;
+
+    public UploadFileDto(UploadFile uploadFile) {
+        this.seq = uploadFile.getSeq();
+        this.originalFileName = uploadFile.getOriginalFileName();
+        this.savedFileName = uploadFile.getSaveFileName();
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/service/PostService.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/service/PostService.java
@@ -1,0 +1,10 @@
+package site.tradelink.tradelink.post.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+    private final PostTransactionalService transactionalService;
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/service/PostTransactionalService.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/service/PostTransactionalService.java
@@ -1,0 +1,9 @@
+package site.tradelink.tradelink.post.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PostTransactionalService {
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/service/file/NcpS3Uploader.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/service/file/NcpS3Uploader.java
@@ -1,0 +1,62 @@
+package site.tradelink.tradelink.post.service.file;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Service
+@RequiredArgsConstructor
+public class NcpS3Uploader {
+
+    private final S3Client s3Client;
+
+    @Value("${cloud.ncp.s3.bucket")
+    private String bucket;
+
+    /**
+     * File.createTempFile() -> 디스크 I/O 병목 가능성으로 인하여 변경
+     * 1. MultipartFile을 S3에 업로드하기 위해 임시파일 생성
+     * 2. MultipartFile.transferTo(tempFile)로 실제 파일을 디스크에 쓴 뒤
+     * 3. S3로 파일 전송(PutObject)
+     * 문제점:
+     * - 운영환경에서 다수의 업로드가 동시 발생할 경우, 디스크 I/O 병목 및 임시 파일 누적 가능성 존재
+     * 대안:
+     * - RequestBody.fromInputStream()
+     */
+    public void uploadFile(MultipartFile multipartFile, String s3Key) {
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+            PutObjectRequest request = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(s3Key)
+                    .contentType(multipartFile.getContentType())
+                    .contentLength(multipartFile.getSize())
+                    .build();
+
+            s3Client.putObject(request, RequestBody.fromInputStream(inputStream, multipartFile.getSize()));
+        } catch (IOException e) {
+            // 추후 Error 작업 추가
+            throw new RuntimeException("파일 업로드 실패", e);
+        }
+    }
+
+    public void deleteFile(String s3Key) {
+        DeleteObjectRequest request = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(s3Key)
+                .build();
+
+        s3Client.deleteObject(request);
+    }
+
+    public String generateUrl(String s3Key) {
+        return "https://" + bucket + ".kr.object.ncloudstorage.com/" + s3Key;
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/service/file/UploadFileService.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/service/file/UploadFileService.java
@@ -1,0 +1,41 @@
+package site.tradelink.tradelink.post.service.file;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import site.tradelink.tradelink.post.util.S3KeyGenerator;
+
+@Service
+@RequiredArgsConstructor
+public class UploadFileService {
+
+    private final UploadFileTransactionalService transactionalService;
+    private final NcpS3Uploader s3Uploader;
+    private final S3KeyGenerator s3KeyGenerator;
+
+    /**
+     * S3 이후 DB(Tx) 하도록 트랜잭션 분리
+     * - 커넥션 고갈 방지
+     * - REDO 영역 최적화
+     * - (낮은 확률) 데드락 방지
+     */
+    public Long savePostPhoto(MultipartFile multipartFile, Long postSeq) {
+        if (multipartFile == null || multipartFile.isEmpty()) {
+            return -1L;
+        }
+
+        String originalFilename = multipartFile.getOriginalFilename();
+        String s3Key = s3KeyGenerator.generatePostPhotoKey(originalFilename);
+
+        // 1) S3 업로드
+        s3Uploader.uploadFile(multipartFile, s3Key);
+
+        // 2) DB 저장 (트랜잭션 안) / 추후 Error 처리 작업 필요
+        try {
+            return transactionalService.savePostPhotoMetadataInTx(originalFilename, s3Key, postSeq);
+        } catch (Exception e) {
+            s3Uploader.deleteFile(s3Key);
+            throw e;
+        }
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/service/file/UploadFileTransactionalService.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/service/file/UploadFileTransactionalService.java
@@ -1,0 +1,35 @@
+package site.tradelink.tradelink.post.service.file;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.tradelink.tradelink.post.entity.Post;
+import site.tradelink.tradelink.post.entity.UploadFile;
+import site.tradelink.tradelink.post.repository.PostRepository;
+import site.tradelink.tradelink.post.repository.file.UploadFileRepository;
+
+@Service
+@RequiredArgsConstructor
+public class UploadFileTransactionalService {
+
+    private final UploadFileRepository uploadFileRepository;
+    private final PostRepository postRepository;
+    private final NcpS3Uploader s3Uploader;
+
+    // 추후 Error 작업 필요
+    @Transactional
+    public Long savePostPhotoMetadataInTx(String originalFilename, String s3Key, Long postSeq) {
+        Post post = postRepository.findById(postSeq)
+                .orElseThrow(() -> new IllegalArgumentException("해당 게시글이 없습니다."));
+
+        UploadFile uploadFile = UploadFile.builder()
+                .originalFileName(originalFilename)
+                .saveFileName(s3Key)
+                .url(s3Uploader.generateUrl(s3Key))
+                .post(post)
+                .build();
+
+        UploadFile saved = uploadFileRepository.save(uploadFile);
+        return saved.getSeq();
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/util/S3KeyGenerator.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/util/S3KeyGenerator.java
@@ -1,0 +1,29 @@
+package site.tradelink.tradelink.post.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class S3KeyGenerator {
+
+     @Value("${cloud.ncp.s3.path.postPhoto}")
+    private String postPhotoPath;
+
+     public String generatePostPhotoKey(String originalFilename) {
+         String ext = extractExt(originalFilename);
+         String uuid = UUID.randomUUID().toString();
+         return postPhotoPath + "/" + uuid + "." + ext;
+     }
+
+    private String extractExt(String fileName) {
+         int pos = fileName.lastIndexOf('.');
+         if (pos == -1 || pos == fileName.length()-1) {
+             // 추후 Error 문구 수정
+             throw  new IllegalArgumentException("파일 확장자를 찾을 수 없습니다.");
+         }
+
+         return fileName.substring(pos+1).toLowerCase();
+    }
+}


### PR DESCRIPTION
파일 업로드 고려한 점 (트랜잭션 분리, 디스크 I/O 병목 최소화)
<디스크 I/O 병목 최소화>
File.createTempFile() -> 디스크 I/O 병목 가능성으로 인하여 변경
1. MultipartFile을 S3에 업로드하기 위해 임시파일 생성
2. MultipartFile.transferTo(tempFile)로 실제 파일을 디스크에 쓴 뒤
3. S3로 파일 전송(PutObject)
문제점:
- 운영환경에서 다수의 업로드가 동시 발생할 경우, 디스크 I/O 병목 및 임시 파일 누적 가능성 존재
대안:
- RequestBody.fromInputStream()
---
<트랜잭션 분리>
S3 이후 DB(Tx) 하도록 트랜잭션 분리
- 커넥션 고갈 방지
- REDO 영역 최적화
- (낮은 확률) 데드락 방지