### PR TITLE
feat:고아 게시글 및 파일 삭제 스케줄러 기능 추가-#13

### DIFF
--- a/tradelink/src/main/java/site/tradelink/tradelink/TradelinkApplication.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/TradelinkApplication.java
@@ -2,7 +2,9 @@ package site.tradelink.tradelink;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class TradelinkApplication {
 

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/common/scheduler/FileDeletionScheduler.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/common/scheduler/FileDeletionScheduler.java
@@ -1,14 +1,84 @@
 package site.tradelink.tradelink.post.common.scheduler;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
-import site.tradelink.tradelink.post.repository.file.UploadFileRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
 import site.tradelink.tradelink.post.service.file.NcpS3Service;
+import software.amazon.awssdk.services.s3.model.S3Object;
+import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
 
-@Component
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
 @RequiredArgsConstructor
 public class FileDeletionScheduler {
 
-    private final UploadFileRepository uploadFileRepository;
     private final NcpS3Service ncpS3Service;
+    private final FileDeletionTransactionalService fileDeletionTransactionalService;
+
+    @Value("${cloud.ncp.s3.path.postPhoto}")
+    private String postPhotoPath;
+
+    private static final int S3_BULK_DELETE_LIMIT = 1000;
+
+    @Scheduled(cron = "0 0 2 * * *")
+    public void cleanupSoftDeletedPostsAndFiles() {
+        List<String> s3KeysToPurge = fileDeletionTransactionalService.findAndPurgeSoftDeletedPosts();
+
+        if (!s3KeysToPurge.isEmpty()) {
+            ncpS3Service.deleteFiles(s3KeysToPurge);
+        }
+    }
+
+    @Scheduled(cron = "0 0 3 * * *")
+    public void cleanupSoftDeletedIndividualFiles() {
+        List<String> s3KeysToPurge = fileDeletionTransactionalService.findAndPurgeSoftDeletedIndividualFiles();
+
+        if (!s3KeysToPurge.isEmpty()) {
+            ncpS3Service.deleteFiles(s3KeysToPurge);
+        }
+    }
+
+    @Scheduled(cron = "0 0 4 * * *")
+    public void cleanupOrphanedS3Files() {
+        Instant cutoff = Instant.now().minus(24, ChronoUnit.HOURS);
+
+        ListObjectsV2Iterable paginatedObjects = ncpS3Service.listObjectsByPrefixPaginated(postPhotoPath);
+
+        paginatedObjects.forEach(page -> {
+            // 1. 현재 페이지에서 유예 기간이 지난 파일 키만 필터링
+            Set<String> s3KeyInPage = page.contents().stream()
+                    .filter(s3Object -> s3Object.lastModified().isBefore(cutoff))
+                    .map(S3Object::key)
+                    .collect(Collectors.toSet());
+
+            if (s3KeyInPage.isEmpty()) {
+                return;
+            }
+
+            // 2. DB에 존재하는 키들을 조회
+            Set<String> existingDbKeys = fileDeletionTransactionalService.filterExistingKeys(s3KeyInPage);
+
+            // 3. 고아 파일 확정
+            s3KeyInPage.removeAll(existingDbKeys);
+
+            // 4. 고아 파일이 있다면, 서버 메모리에 쌓아두지 않고 즉시 삭제
+            if (!s3KeyInPage.isEmpty()) {
+                List<String> orphanKeysInPage = new ArrayList<>(s3KeyInPage);
+
+                // S3 벌크 삭제 제한(1000개)에 맞춰 분할 삭제
+                for (int i=0; i< orphanKeysInPage.size(); i += S3_BULK_DELETE_LIMIT) {
+                    List<String> subList = orphanKeysInPage.subList(i, Math.min(i + S3_BULK_DELETE_LIMIT, orphanKeysInPage.size()));
+                    ncpS3Service.deleteFiles(subList);
+
+                }
+            }
+        });
+    }
 }

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/common/scheduler/FileDeletionTransactionalService.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/common/scheduler/FileDeletionTransactionalService.java
@@ -1,0 +1,75 @@
+package site.tradelink.tradelink.post.common.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.tradelink.tradelink.post.common.enums.FileStatus;
+import site.tradelink.tradelink.post.common.enums.PostStatus;
+import site.tradelink.tradelink.post.entity.Post;
+import site.tradelink.tradelink.post.entity.UploadFile;
+import site.tradelink.tradelink.post.repository.PostRepository;
+import site.tradelink.tradelink.post.repository.file.UploadFileRepository;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class FileDeletionTransactionalService {
+
+    private final UploadFileRepository uploadFileRepository;
+    private final PostRepository postRepository;
+
+    final int RETENTION_DAYS = 1;
+
+    @Transactional
+    public List<String> findAndPurgeSoftDeletedPosts() {
+        LocalDateTime cutoffDate = LocalDateTime.now().minusDays(RETENTION_DAYS);
+        List<Post> postsToPurge = postRepository.findByStatusAndDeletedTimeBefore(PostStatus.DELETED, cutoffDate);
+
+        if (postsToPurge.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<String> s3KeysToPurge = postsToPurge.stream()
+                .flatMap(post -> post.getUploadFiles().stream())
+                .map(UploadFile::getS3Key)
+                .toList();
+
+        postRepository.deleteAllInBatch(postsToPurge);
+
+        return s3KeysToPurge;
+    }
+
+    @Transactional
+    public List<String> findAndPurgeSoftDeletedIndividualFiles() {
+        LocalDateTime cutoffDate = LocalDateTime.now().minusDays(RETENTION_DAYS);
+        List<UploadFile> filesToPurge = uploadFileRepository.findByStatusAndDeletedTimeBefore(FileStatus.DELETED, cutoffDate);
+
+        if (filesToPurge.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<String> s3KeysToPurge = filesToPurge.stream()
+                .map(UploadFile::getS3Key)
+                .toList();
+
+        uploadFileRepository.deleteAllInBatch(filesToPurge);
+
+        return s3KeysToPurge;
+    }
+
+    /**
+     * S3에서 조회한 키 목록(한 페이지 분량)을 받아 DB에 존재하는 키만 필터링하여 반환
+     */
+    @Transactional(readOnly = true)
+    public Set<String> filterExistingKeys(Set<String> s3KeysFromPage) {
+        if (s3KeysFromPage == null || s3KeysFromPage.isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        return uploadFileRepository.findExistingS3Keys(s3KeysFromPage);
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/common/util/S3KeyGenerator.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/common/util/S3KeyGenerator.java
@@ -8,7 +8,7 @@ import java.util.UUID;
 @Component
 public class S3KeyGenerator {
 
-     @Value("${cloud.ncp.s3.path.postPhoto}")
+    @Value("${cloud.ncp.s3.path.postPhoto}")
     private String postPhotoPath;
 
      public String generatePostPhotoKey(String originalFilename) {

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/repository/PostRepository.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/repository/PostRepository.java
@@ -1,12 +1,24 @@
 package site.tradelink.tradelink.post.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import site.tradelink.tradelink.post.common.enums.PostStatus;
 import site.tradelink.tradelink.post.entity.Post;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+    // Query에 PostStatus.ACTIVE를 활성화 해야함
     Optional<Post> findActivePostWithDetailsBySeq(Long postSeq);
     Optional<Post> findActivePostWithFilesBySeqAndMemberSeq(Long poseSeq, Long memberSeq);
     Optional<Post> findActivePostBySeqAndMemberSeq(Long postSeq, Long memberSeq);
+
+    /**
+     * soft-delete된 게시글들 중 특정 시간 이전에 삭제된 것들을 조회
+     * @param status DELETED 상태
+     * @param cutoffDate 기준 시간
+     * @return List<Post>
+     */
+    List<Post> findByStatusAndDeletedTimeBefore(PostStatus status, LocalDateTime cutoffDate);
 }

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/repository/file/UploadFileRepository.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/repository/file/UploadFileRepository.java
@@ -1,8 +1,15 @@
 package site.tradelink.tradelink.post.repository.file;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import site.tradelink.tradelink.post.common.enums.FileStatus;
 import site.tradelink.tradelink.post.entity.UploadFile;
 
-public interface UploadFileRepository extends JpaRepository<UploadFile, Long> {
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
 
+public interface UploadFileRepository extends JpaRepository<UploadFile, Long> {
+    List<UploadFile> findByStatusAndDeletedTimeBefore(FileStatus status, LocalDateTime cutoffDate);
+
+    Set<String> findExistingS3Keys(Set<String> s3Keys);
 }

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/service/file/NcpS3Service.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/service/file/NcpS3Service.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
+import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -60,16 +61,16 @@ public class NcpS3Service {
         return failureKeys;
     }
 
-    public List<S3Object> listAllObjectsByPrefix(String prefix) {
-        try {
-            ListObjectsV2Request listReq = ListObjectsV2Request.builder()
-                    .bucket(bucket)
-                    .prefix(prefix)
-                    .build();
+    /**
+     * S3 객체 목록을 페이지네이션하여 가져오는 Iterable을 반환
+     * 대용량 데이터를 메모리 문제 없이 처리하기 위해 사용
+     */
+    public ListObjectsV2Iterable listObjectsByPrefixPaginated(String prefix) {
+        ListObjectsV2Request listReq = ListObjectsV2Request.builder()
+                .bucket(bucket)
+                .prefix(prefix)
+                .build();
 
-            return s3Client.listObjectsV2(listReq).contents();
-        } catch (S3Exception e) {
-            return Collections.emptyList();
-        }
+        return s3Client.listObjectsV2Paginator(listReq);
     }
 }


### PR DESCRIPTION
추가 및 개선한 점
1. UploadFile의 삭제 방식을 hard -> soft로 변경
2. UploadFile의 Status가 Deleted인(즉, soft delete된 상태) 객체들을 삭제(DB 및 S3)하는 Scheduler 추가
3. Post의 Status가 Deleted인(즉, soft delete된 상태) 객체들을 삭제(DB)하는 Scheduler 추가
4. 3. 작업에서 Post에 연관된 UploadFile 객체들을 삭제(S3)
5. 이미지를 추가하고 사용자가 게시글을 저장하지 않고 작업을 중단한다면, 해당 이미지는 고아 상태로 S3에 존재하게 되어 정합성이 깨지게 됨. 이것을 정리하는 Scheduler 추가

핵심적인 개선 사항
위 5번 작업에서 2가지 문제점을 발견
1. 경쟁 상태 : 사용자가 정상적으로 파일을 업로드하는 중 스케줄러가 해당 파일을 삭제하는 문제가 발생
2. 성능 및 메모리 최적화 이슈 : S3에 있는 파일을 서버 메모리에 전부 올린 후 고아 파일을 체크하는 작업을 거침 -> 해당 과정에서 OOM 및 GC 성능 저하 이슈가 발생

해결 방안
1. 유예 기간 도입 : 업로드된 지 24시간이 지난 파일만을 삭제 후보로 간주하여 경쟁 상태 문제를 원천적으로 차단
2. 페이지네이션 처리 : S3와 DB의 모든 파일 목록을 한 번에 메모리에 올리는 대신, 정해진 크기(페이지)로 나누어 처리하여 메모리 사용량을 최소화

앞으로 개선할 점
현재 S3에서 고아 파일 삭제 실패 시에 추가 작업이 없음. 즉, 정합성이 깨지게 됨. 이것을 해결하기 위한 Retry 작업 혹은 Event 작업 추가 계획