### PR TITLE
feat:S3에서 파일 삭제 실패 시 후속 처리 기능 추가-#14

### DIFF
--- a/tradelink/build.gradle
+++ b/tradelink/build.gradle
@@ -59,6 +59,10 @@ dependencies {
 	implementation platform('software.amazon.awssdk:bom:2.27.21')
 	implementation 'software.amazon.awssdk:s3'
 	implementation 'software.amazon.awssdk:s3-presigner'
+
+	// eventListener
+	implementation 'org.springframework.retry:spring-retry'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 tasks.named('test') {

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/common/event/S3DeletionFailureEvent.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/common/event/S3DeletionFailureEvent.java
@@ -1,0 +1,15 @@
+package site.tradelink.tradelink.post.common.event;
+
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class S3DeletionFailureEvent{
+
+    private final Map<String, String> failedKeysWithReason;
+
+    public S3DeletionFailureEvent(Map<String, String> failedKeysWithReason) {
+        this.failedKeysWithReason = failedKeysWithReason;
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/common/eventListener/S3DeletionFailureEventListener.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/common/eventListener/S3DeletionFailureEventListener.java
@@ -1,0 +1,41 @@
+package site.tradelink.tradelink.post.common.eventListener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import site.tradelink.tradelink.post.common.event.S3DeletionFailureEvent;
+import site.tradelink.tradelink.post.common.exception.S3DeletionException;
+import site.tradelink.tradelink.post.service.file.NcpS3Service;
+
+import java.util.ArrayList;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3DeletionFailureEventListener {
+
+    private final NcpS3Service ncpS3Service;
+
+    @Async
+    @EventListener
+    @Retryable(
+            retryFor = {S3DeletionException.class},
+            maxAttempts = 5,
+            backoff = @Backoff(delay = 3000) // 3초 간격
+    )
+    public void handleS3DeletionFailure(S3DeletionFailureEvent event) {
+        ArrayList<String> keysToRetry = new ArrayList<>(event.getFailedKeysWithReason().keySet());
+
+        ncpS3Service.deleteFiles(keysToRetry);
+    }
+
+    @Recover
+    public void notifyDeletionFailure(S3DeletionException e) {
+        log.error("S3 파일 삭제 재시도에 최종 실패했습니다. 수동 확인 필요. 실패 목록: {}", e.getFailures());
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/common/exception/S3DeletionException.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/common/exception/S3DeletionException.java
@@ -1,0 +1,16 @@
+package site.tradelink.tradelink.post.common.exception;
+
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class S3DeletionException extends RuntimeException{
+
+    private final Map<String, String> failures;
+
+    public S3DeletionException(String message, Map<String, String> failures) {
+        super(message);
+        this.failures = failures;
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/common/scheduler/FileDeletionScheduler.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/common/scheduler/FileDeletionScheduler.java
@@ -2,8 +2,11 @@ package site.tradelink.tradelink.post.common.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import site.tradelink.tradelink.post.common.event.S3DeletionFailureEvent;
+import site.tradelink.tradelink.post.common.exception.S3DeletionException;
 import site.tradelink.tradelink.post.service.file.NcpS3Service;
 import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
@@ -21,6 +24,7 @@ public class FileDeletionScheduler {
 
     private final NcpS3Service ncpS3Service;
     private final FileDeletionTransactionalService fileDeletionTransactionalService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Value("${cloud.ncp.s3.path.postPhoto}")
     private String postPhotoPath;
@@ -32,7 +36,11 @@ public class FileDeletionScheduler {
         List<String> s3KeysToPurge = fileDeletionTransactionalService.findAndPurgeSoftDeletedPosts();
 
         if (!s3KeysToPurge.isEmpty()) {
-            ncpS3Service.deleteFiles(s3KeysToPurge);
+            try {
+                ncpS3Service.deleteFiles(s3KeysToPurge);
+            } catch (S3DeletionException e) {
+                eventPublisher.publishEvent(new S3DeletionFailureEvent(e.getFailures()));
+            }
         }
     }
 
@@ -41,7 +49,11 @@ public class FileDeletionScheduler {
         List<String> s3KeysToPurge = fileDeletionTransactionalService.findAndPurgeSoftDeletedIndividualFiles();
 
         if (!s3KeysToPurge.isEmpty()) {
-            ncpS3Service.deleteFiles(s3KeysToPurge);
+            try {
+                ncpS3Service.deleteFiles(s3KeysToPurge);
+            } catch (S3DeletionException e) {
+                eventPublisher.publishEvent(new S3DeletionFailureEvent(e.getFailures()));
+            }
         }
     }
 
@@ -75,8 +87,12 @@ public class FileDeletionScheduler {
                 // S3 벌크 삭제 제한(1000개)에 맞춰 분할 삭제
                 for (int i=0; i< orphanKeysInPage.size(); i += S3_BULK_DELETE_LIMIT) {
                     List<String> subList = orphanKeysInPage.subList(i, Math.min(i + S3_BULK_DELETE_LIMIT, orphanKeysInPage.size()));
-                    ncpS3Service.deleteFiles(subList);
 
+                    try {
+                        ncpS3Service.deleteFiles(subList);
+                    } catch (S3DeletionException e) {
+                        eventPublisher.publishEvent(new S3DeletionFailureEvent(e.getFailures()));
+                    }
                 }
             }
         });

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/service/file/NcpS3Service.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/service/file/NcpS3Service.java
@@ -3,6 +3,7 @@ package site.tradelink.tradelink.post.service.file;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import site.tradelink.tradelink.post.common.exception.S3DeletionException;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Iterable;
@@ -19,9 +20,9 @@ public class NcpS3Service {
     @Value("${cloud.ncp.s3.bucket}")
     private String bucket;
 
-    public Map<String, String> deleteFiles(List<String> s3Keys) {
+    public void deleteFiles(List<String> s3Keys) {
         if (s3Keys == null || s3Keys.isEmpty()) {
-            return Collections.emptyMap();
+            return;
         }
 
         List<String> sanitizedKeys = s3Keys.stream()
@@ -35,7 +36,7 @@ public class NcpS3Service {
                 .collect(Collectors.toList());
 
         if (toDelete.isEmpty()) {
-            return Collections.emptyMap();
+            return;
         }
 
         DeleteObjectsRequest deleteReq = DeleteObjectsRequest.builder()
@@ -58,7 +59,9 @@ public class NcpS3Service {
             sanitizedKeys.forEach(key -> failureKeys.put(key, e.awsErrorDetails().errorMessage()));
         }
 
-        return failureKeys;
+        if (!failureKeys.isEmpty()) {
+            throw new S3DeletionException("S3 파일 삭제 중 일부 또는 전체 실패", failureKeys);
+        }
     }
 
     /**


### PR DESCRIPTION
S3 파일 삭제 실패 시 후속 처리 기능 구현

기존에는 로그를 남기는 것으로 작업이 종료되었으나,
파일 삭제 실패 시 해당 이벤트를 발행한 후, 그 이벤트를 수신하는 이벤트 리스너 기능 추가(비동기)
총 5번의 S3 파일 삭제 작업을 재시도하여 S3와 DB간의 정합성 강화