### PR TITLE
feat:댓글 읽기 기능 추가-#16

### DIFF
--- a/tradelink/src/main/java/site/tradelink/tradelink/comment/service/CommentService.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/comment/service/CommentService.java
@@ -2,9 +2,16 @@ package site.tradelink.tradelink.comment.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import site.tradelink.tradelink.comment.entity.Comment;
 import site.tradelink.tradelink.comment.request.CommentCreateDto;
 import site.tradelink.tradelink.comment.request.CommentUpdateDto;
 import site.tradelink.tradelink.comment.response.CommentResponseDto;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -24,5 +31,32 @@ public class CommentService {
         transactionalService.deleteComment(commentSeq, memberSeq);
     }
 
-    public List<CommentResponseDto>
+    public List<CommentResponseDto> getCommentsForPost(Long postSeq) {
+        List<Comment> comments = transactionalService.getCommentsByPostSeq(postSeq);
+
+        LinkedHashMap<Long, CommentResponseDto> dtoMap = comments.stream()
+                .map(CommentResponseDto::from)
+                .collect(Collectors.toMap(
+                        CommentResponseDto::commentSeq,
+                        dto -> dto,
+                        (existing, replacement) -> existing,
+                        LinkedHashMap::new
+                ));
+
+        List<CommentResponseDto> rootComments = new ArrayList<>();
+
+        comments.forEach(comment -> {
+            CommentResponseDto currentDto = dtoMap.get(comment.getSeq());
+            if (comment.getParent() != null) {
+                CommentResponseDto parentDto = dtoMap.get(comment.getParent().getSeq());
+                if (parentDto != null) {
+                    parentDto.replies().add(currentDto);
+                }
+            } else {
+                rootComments.add(currentDto);
+            }
+        });
+
+        return Collections.unmodifiableList(rootComments);
+    }
 }

--- a/tradelink/src/main/java/site/tradelink/tradelink/comment/service/CommentTransactionalService.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/comment/service/CommentTransactionalService.java
@@ -22,8 +22,6 @@ public class CommentTransactionalService {
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
 
-    private static final int MAX_DEPTH = 1;
-
     @Transactional
     public Long createComment(Long postSeq, Long memberSeq, CommentCreateDto request) {
         // 추후 Error 작업 추가
@@ -41,7 +39,7 @@ public class CommentTransactionalService {
             if (clickedParentComment.getDepth() == 0) {
                 actualParentComment = clickedParentComment;
             } else {
-                actualParentComment = clickedParentComment;
+                actualParentComment = clickedParentComment.getParent();
             }
         }
 


### PR DESCRIPTION
댓글 및 대댓글(max depth = 1) 읽기 기능 추가

추후 해야할 것
- 댓글 삭제 스케줄링 (현재는 Soft Delete 상태)
- 게시글 및 댓글 비동기 응답 (Front-End에서 게시글 및 댓글 API 각 호출 or API Gateway 패턴을 도입하여 공통 API에서 각 게시글 및 댓글 API를 호출하는 방법 중 고민 중에 있음)