### PR TITLE
feat: 게시글 좋아요 스케줄러 및 DLQ 기능 추가-#19

### DIFF
--- a/tradelink/src/main/java/site/tradelink/tradelink/like/common/scheduler/processLikeEvents.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/like/common/scheduler/processLikeEvents.java
@@ -1,0 +1,175 @@
+package site.tradelink.tradelink.like.common.scheduler;
+
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import site.tradelink.tradelink.like.common.enums.ActionType;
+import site.tradelink.tradelink.like.entity.LikePostEvent;
+import site.tradelink.tradelink.like.entity.LikeStatus;
+import site.tradelink.tradelink.like.entity.PostStats;
+import site.tradelink.tradelink.like.entity.ProcessorOffset;
+import site.tradelink.tradelink.like.repository.LikePostEventRepository;
+import site.tradelink.tradelink.like.repository.LikeStatusRepository;
+import site.tradelink.tradelink.like.repository.PostStatsRepository;
+import site.tradelink.tradelink.like.repository.ProcessorOffsetRepository;
+import site.tradelink.tradelink.like.service.failed.LikeEventDLQService;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class processLikeEvents {
+
+    private final LikeEventDLQService likeEventDLQService;
+
+    private final LikePostEventRepository likePostEventRepository;
+    private final LikeStatusRepository likeStatusRepository;
+    private final PostStatsRepository postStatsRepository;
+    private final ProcessorOffsetRepository processorOffsetRepository;
+
+    private static final String PROCESSOR_KEY = "LIKE_POST_PROCESSOR";
+    private static final int BATCH_SIZE = 100;
+
+    @Scheduled(fixedDelay = 5000)
+    @Transactional
+    public void processLikeEvents() {
+        ProcessorOffset offset = getOrInitOffset();
+        Long lastSeq = offset.getLastProcessedEventSeq();
+
+        List<LikePostEvent> events = likePostEventRepository.findEventsAfterCursor(
+                lastSeq, PageRequest.of(0, BATCH_SIZE));
+
+        if (events.isEmpty()) {
+            return;
+        }
+
+        BatchProcessResult result = processBatchWithDLQ(events);
+
+        // memory에서 각 post의 좋아요 count 계산을 끝마친 후 DB Update
+        updatePostStatsInBatch(result.postLikeDeltaMap);
+
+        offset.updateOffset(result.lastProcessedSeq);
+    }
+
+    private void updatePostStatsInBatch(Map<Long, Long> postLikeDeltaMap) {
+        if (postLikeDeltaMap.isEmpty()) {
+            return;
+        }
+
+        List<Long> postSeqs = new ArrayList<>(postLikeDeltaMap.keySet());
+        List<PostStats> statsList = postStatsRepository.findAllByPostSeqIn(postSeqs);
+
+        Map<Long, PostStats> statsMap = new HashMap<>();
+        for (PostStats stats : statsList) {
+            statsMap.put(stats.getPostSeq(), stats);
+        }
+
+        for (Map.Entry<Long, Long> entry : postLikeDeltaMap.entrySet()) {
+            Long postSeq = entry.getKey();
+            Long delta = entry.getValue();
+
+            PostStats stats = statsMap.get(postSeq);
+            if (stats != null) {
+                stats.setLikeCount(stats.getLikeCount() + delta);
+            } else {
+                PostStats newStats = PostStats.builder()
+                        .postSeq(postSeq)
+                        .likeCount(Math.max(0, delta))
+                        .build();
+
+                statsList.add(newStats);
+            }
+        }
+
+        postStatsRepository.saveAll(statsList);
+    }
+
+    /**
+     * 배치 처리 with DLQ
+     * - 실패한 이벤트는 DLQ로 이동
+     * - 나머지는 계속 진행
+     */
+    private BatchProcessResult processBatchWithDLQ(List<LikePostEvent> events) {
+        Map<Long, Long> postLikeDeltaMap = new HashMap<>();
+        long lastProcessedSeq = events.getFirst().getSeq() - 1;
+        int successCount = 0;
+        int skippedCount = 0; // 현재의 DB 기반 이벤트 로그에서는 불필요함 BUT. 이벤트 메시징(Kafka, RabbitMQ, SQS 등을 사용할 경우 필요해짐. 코드 확장성에 따른 변수 추가.
+        int failedCount = 0;
+
+        for (LikePostEvent event : events) {
+            try {
+                boolean statusChanged = processSingleLikeStatus(event);
+
+                if (statusChanged) {
+                    long delta = (event.getActionType() == ActionType.LIKE) ? 1L : -1L;
+                    postLikeDeltaMap.merge(event.getPostSeq(), delta, Long::sum);
+                    successCount++;
+                } else {
+                    skippedCount++;
+                }
+
+                // 성공하면 offset 이동
+                lastProcessedSeq = event.getSeq();
+
+            } catch (Exception e) {
+                failedCount++;
+
+                // DLQ로 이동 (별도 트랜잭션)
+                likeEventDLQService.moveToDLQ(event);
+
+                // 실패해도 offset 이동 *(Poison Pill 방지)*
+                lastProcessedSeq = event.getSeq();
+            }
+        }
+
+        return BatchProcessResult.builder()
+                .postLikeDeltaMap(postLikeDeltaMap)
+                .lastProcessedSeq(lastProcessedSeq)
+                .successCount(successCount)
+                .skippedCount(skippedCount)
+                .failedCount(failedCount)
+                .build();
+    }
+
+    private boolean processSingleLikeStatus(LikePostEvent event) {
+        LikeStatus likeStatus = likeStatusRepository.findByMemberSeqAndPostSeq(event.getMemberSeq(), event.getPostSeq())
+                .orElseGet(() -> likeStatusRepository.save(LikeStatus.builder()
+                        .memberSeq(event.getMemberSeq())
+                        .postSeq(event.getPostSeq())
+                        .isLiked(false)
+                        .build()));
+
+        boolean isLikedAction = event.getActionType() == ActionType.LIKE;
+
+        if (likeStatus.getIsLiked().equals(isLikedAction)) {
+            return false;
+        }
+
+        likeStatus.updateLikeStatus(isLikedAction);
+        return true;
+    }
+
+    private ProcessorOffset getOrInitOffset() {
+        return processorOffsetRepository.findByProcessorName(PROCESSOR_KEY)
+                .orElseGet(() -> processorOffsetRepository.save(
+                        ProcessorOffset.builder()
+                                .processorName(PROCESSOR_KEY)
+                                .lastProcessedEventSeq(0L)
+                                .build()));
+    }
+
+    @Builder
+    private static class BatchProcessResult {
+        Map<Long, Long> postLikeDeltaMap;
+        Long lastProcessedSeq;
+        int successCount;
+        int skippedCount;
+        int failedCount;
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/like/entity/failed/LikeEventDLQ.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/like/entity/failed/LikeEventDLQ.java
@@ -1,0 +1,38 @@
+package site.tradelink.tradelink.like.entity.failed;
+
+import jakarta.persistence.*;
+import lombok.*;
+import site.tradelink.tradelink.common.entity.BaseEntity;
+import site.tradelink.tradelink.like.common.enums.ActionType;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class LikeEventDLQ extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "dlq_seq")
+    private Long seq;
+
+    @Column(nullable = false)
+    private Long originalEventSeq;
+
+    @Column(nullable = false)
+    private Long memberSeq;
+
+    @Column(nullable = false)
+    private Long postSeq;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ActionType actionType;
+
+    @Column(nullable = false)
+    private Integer retryCount;
+
+    public void incrementRetryCount() {
+        this.retryCount++;
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/like/repository/PostStatsRepository.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/like/repository/PostStatsRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import site.tradelink.tradelink.like.entity.PostStats;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,4 +16,6 @@ public interface PostStatsRepository extends JpaRepository<PostStats, Long> {
 
     @Query("SELECT ps FROM PostStats ps WHERE ps.postSeq IN :postSeqs")
     List<PostStats> findAllByPostSeqs(@Param("postSeqs") List<Long> postSeqs);
+
+    List<PostStats> findAllByPostSeqIn(Collection<Long> postSeqs);
 }

--- a/tradelink/src/main/java/site/tradelink/tradelink/like/repository/ProcessorOffsetRepository.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/like/repository/ProcessorOffsetRepository.java
@@ -13,8 +13,4 @@ import java.util.Optional;
 @Repository
 public interface ProcessorOffsetRepository extends JpaRepository<ProcessorOffset, Long> {
     Optional<ProcessorOffset> findByProcessorName(String processorName);
-
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("SELECT po FROM ProcessorOffset po WHERE po.processorName = :processorName")
-    Optional<ProcessorOffset> findByProcessorNameWithLock(@Param("processorName") String processorName);
 }

--- a/tradelink/src/main/java/site/tradelink/tradelink/like/repository/failed/LikeEventDLQRepository.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/like/repository/failed/LikeEventDLQRepository.java
@@ -1,0 +1,21 @@
+package site.tradelink.tradelink.like.repository.failed;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import site.tradelink.tradelink.like.entity.failed.LikeEventDLQ;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface LikeEventDLQRepository extends JpaRepository<LikeEventDLQ, Long> {
+
+    Optional<LikeEventDLQ> findByOriginalEventSeq(Long originalEventSeq);
+
+    @Query("SELECT d FROM LikeEventDLQ d WHERE d.retryCount < :maxRetry ORDER BY d.seq ASC")
+    List<LikeEventDLQ> findRetryableEvents(@Param("maxRetry") int maxRetry);
+
+    long countByRetryCountGreaterThanEqual(int retryCount);
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/like/service/failed/LikeEventDLQService.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/like/service/failed/LikeEventDLQService.java
@@ -1,0 +1,38 @@
+package site.tradelink.tradelink.like.service.failed;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import site.tradelink.tradelink.like.entity.LikePostEvent;
+import site.tradelink.tradelink.like.entity.failed.LikeEventDLQ;
+import site.tradelink.tradelink.like.repository.failed.LikeEventDLQRepository;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class LikeEventDLQService {
+
+    private final LikeEventDLQRepository likeEventDLQRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void moveToDLQ(LikePostEvent event) {
+        Optional<LikeEventDLQ> existingDLQ = likeEventDLQRepository.findByOriginalEventSeq(event.getSeq());
+
+        if (existingDLQ.isPresent()) {
+            // 이미 DLQ에 있으면 재시도 카운트 증가
+            LikeEventDLQ dlq = existingDLQ.get();
+            dlq.incrementRetryCount();
+        } else {
+            LikeEventDLQ dlq = LikeEventDLQ.builder()
+                    .originalEventSeq(event.getSeq())
+                    .memberSeq(event.getMemberSeq())
+                    .postSeq(event.getPostSeq())
+                    .actionType(event.getActionType())
+                    .retryCount(1)
+                    .build();
+            likeEventDLQRepository.save(dlq);
+        }
+    }
+}


### PR DESCRIPTION
[안정성 확보]
- DLQ(Dead Letter Queue) 패턴 도입: 처리 실패 이벤트를 별도 테이블로 격리하여 Poison Pill 방지
- 트랜잭션 분리: Spring AOP Self-invocation 문제 해결을 위해 DLQ 로직을 Service로 분리
- 실패 시 메인 로직 롤백과 무관하게 실패 로그(DLQ)가 커밋되도록 REQUIRES_NEW 전파 속성 적용

추후 할 작업
- DLQ 스케줄러 기능 추가