### PR TITLE
feat: DLQ 이벤트 재처리 스케줄러 기능 추가-#20

### DIFF
--- a/tradelink/src/main/java/site/tradelink/tradelink/like/common/scheduler/failed/DLQRetryScheduler.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/like/common/scheduler/failed/DLQRetryScheduler.java
@@ -1,0 +1,72 @@
+package site.tradelink.tradelink.like.common.scheduler.failed;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import site.tradelink.tradelink.like.entity.LikePostEvent;
+import site.tradelink.tradelink.like.entity.failed.LikeEventDLQ;
+import site.tradelink.tradelink.like.repository.failed.LikeEventDLQRepository;
+import site.tradelink.tradelink.like.service.LikeEventProcessor;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class DLQRetryScheduler {
+
+    private final LikeEventProcessor likeEventProcessor;
+
+    private final LikeEventDLQRepository dlqRepository;
+
+    private static final int MAX_RETRY_COUNT = 3;
+    private static final int RETRY_BATCH_SIZE = 10;
+
+    /**
+     * DLQ에 있는 이벤트 재처리
+     * - 매 1분마다 실행
+     * - 재시도 횟수가 MAX_RETRY_COUNT 미만인 것만
+     */
+    @Scheduled(fixedDelay = 60000)
+    @Transactional
+    public void retryFailedEvents() {
+        List<LikeEventDLQ> retryableEvents = dlqRepository.findRetryableEvents(MAX_RETRY_COUNT)
+                .stream()
+                .limit(RETRY_BATCH_SIZE)
+                .toList();
+
+        if (retryableEvents.isEmpty()) {
+            return;
+        }
+
+        int successCount = 0;
+        int failureCount = 0;
+
+        for  (LikeEventDLQ dlqEvent : retryableEvents) {
+            try {
+                // DLQ 이벤트를 원본 이벤트로 변환
+                LikePostEvent originalEvent = LikePostEvent.builder()
+                        .seq(dlqEvent.getOriginalEventSeq())
+                        .memberSeq(dlqEvent.getMemberSeq())
+                        .postSeq(dlqEvent.getPostSeq())
+                        .actionType(dlqEvent.getActionType())
+                        .build();
+
+                // 재처리 시도
+                boolean statusChanged = likeEventProcessor.processSingleLikeStatus(originalEvent);
+
+                if (statusChanged) {
+                    //성공하면 DLQ에서 삭제
+                    dlqRepository.delete(dlqEvent);
+                    successCount++;
+                } else {
+                    // 중복 이벤트면 DLQ에서 삭제 BUT. 현재 아키텍처에서는 해당 코드로 진입하지 않음, 이벤트 메시징 기반을 염두한 코드
+                    dlqRepository.delete(dlqEvent);
+                }
+            } catch (Exception e) {
+                failureCount++;
+                dlqEvent.incrementRetryCount();
+            }
+        }
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/like/common/scheduler/processLikeEvents.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/like/common/scheduler/processLikeEvents.java
@@ -15,6 +15,7 @@ import site.tradelink.tradelink.like.repository.LikePostEventRepository;
 import site.tradelink.tradelink.like.repository.LikeStatusRepository;
 import site.tradelink.tradelink.like.repository.PostStatsRepository;
 import site.tradelink.tradelink.like.repository.ProcessorOffsetRepository;
+import site.tradelink.tradelink.like.service.LikeEventProcessor;
 import site.tradelink.tradelink.like.service.failed.LikeEventDLQService;
 
 import java.util.ArrayList;
@@ -27,9 +28,9 @@ import java.util.Map;
 public class processLikeEvents {
 
     private final LikeEventDLQService likeEventDLQService;
+    private final LikeEventProcessor likeEventProcessor;
 
     private final LikePostEventRepository likePostEventRepository;
-    private final LikeStatusRepository likeStatusRepository;
     private final PostStatsRepository postStatsRepository;
     private final ProcessorOffsetRepository processorOffsetRepository;
 
@@ -104,7 +105,7 @@ public class processLikeEvents {
 
         for (LikePostEvent event : events) {
             try {
-                boolean statusChanged = processSingleLikeStatus(event);
+                boolean statusChanged = likeEventProcessor.processSingleLikeStatus(event);
 
                 if (statusChanged) {
                     long delta = (event.getActionType() == ActionType.LIKE) ? 1L : -1L;
@@ -135,24 +136,6 @@ public class processLikeEvents {
                 .skippedCount(skippedCount)
                 .failedCount(failedCount)
                 .build();
-    }
-
-    private boolean processSingleLikeStatus(LikePostEvent event) {
-        LikeStatus likeStatus = likeStatusRepository.findByMemberSeqAndPostSeq(event.getMemberSeq(), event.getPostSeq())
-                .orElseGet(() -> likeStatusRepository.save(LikeStatus.builder()
-                        .memberSeq(event.getMemberSeq())
-                        .postSeq(event.getPostSeq())
-                        .isLiked(false)
-                        .build()));
-
-        boolean isLikedAction = event.getActionType() == ActionType.LIKE;
-
-        if (likeStatus.getIsLiked().equals(isLikedAction)) {
-            return false;
-        }
-
-        likeStatus.updateLikeStatus(isLikedAction);
-        return true;
     }
 
     private ProcessorOffset getOrInitOffset() {

--- a/tradelink/src/main/java/site/tradelink/tradelink/like/service/LikeEventProcessor.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/like/service/LikeEventProcessor.java
@@ -1,0 +1,35 @@
+package site.tradelink.tradelink.like.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.tradelink.tradelink.like.common.enums.ActionType;
+import site.tradelink.tradelink.like.entity.LikePostEvent;
+import site.tradelink.tradelink.like.entity.LikeStatus;
+import site.tradelink.tradelink.like.repository.LikeStatusRepository;
+
+@Service
+@RequiredArgsConstructor
+public class LikeEventProcessor {
+
+    private final LikeStatusRepository likeStatusRepository;
+
+    @Transactional
+    public boolean processSingleLikeStatus(LikePostEvent event) {
+        LikeStatus likeStatus = likeStatusRepository.findByMemberSeqAndPostSeq(event.getMemberSeq(), event.getPostSeq())
+                .orElseGet(() -> likeStatusRepository.save(LikeStatus.builder()
+                        .memberSeq(event.getMemberSeq())
+                        .postSeq(event.getPostSeq())
+                        .isLiked(false)
+                        .build()));
+
+        boolean isLikedAction = event.getActionType() == ActionType.LIKE;
+
+        if (likeStatus.getIsLiked().equals(isLikedAction)) {
+            return false;
+        }
+
+        likeStatus.updateLikeStatus(isLikedAction);
+        return true;
+    }
+}


### PR DESCRIPTION
[구조 개선]
- 초기에는 Scheduler 내부에 이벤트 처리 로직을 두었으나, DLQ 재처리 스케줄러가 추가되면서 Scheduler 간 의존이 생김
- 공통 이벤트 처리 로직(processSingleLikeStatus)을 Processor(Service)로 분리
- 즉, 순환 참조 제거: DLQRetryScheduler가 MainScheduler(processLikeEvents)를 의존하던 구조 개선

추후 할 작업
- 이벤트_로그_테이블(LikePostEvent) tuple 삭제
- Scheduler 주기 동적 변환 수정