### PR TITLE
feat: 한국은행 환율 API 연동-#25

### DIFF
--- a/tradelink/src/main/java/site/tradelink/tradelink/stock/authorization/scheduler/BokApiClient.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/stock/authorization/scheduler/BokApiClient.java
@@ -1,0 +1,82 @@
+package site.tradelink.tradelink.stock.authorization.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import site.tradelink.tradelink.stock.authorization.scheduler.dto.BokApiExchangeRateDto;
+import site.tradelink.tradelink.stock.authorization.scheduler.enums.Currency;
+import site.tradelink.tradelink.stock.authorization.scheduler.enums.StatisticCode;
+import site.tradelink.tradelink.stock.authorization.scheduler.validate.BokApiResponseValidator;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * 한국은행 Open API 클라이언트
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BokApiClient {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final RestClient bokRestClient;
+    private final BokApiResponseValidator validator;
+
+    @Value("${bok.api.auth-key}")
+    private String authKey;
+
+    /**
+     * 최신 환율 조회 (당일)
+     */
+    public BokApiExchangeRateDto.Row getLatestExchangeRate(Currency currency) {
+        LocalDate today = LocalDate.now();
+        
+        BokApiExchangeRateDto.BokApiExchangeRateResponse response = fetchData(
+                StatisticCode.EXCHANGE_RATE,
+                currency.getItemCode(),
+                today,
+                today
+        );
+
+        validator.validate(response);
+
+        return response.getStatisticSearch().getRows().getFirst();
+    }
+
+    /**
+     * 데이터 조회
+     */
+    private BokApiExchangeRateDto.BokApiExchangeRateResponse fetchData(StatisticCode statCode, String itemCode, LocalDate startDate, LocalDate endDate) {
+        String uri = buildUri(statCode, itemCode, startDate, endDate);
+
+        try {
+            return bokRestClient.get()
+                    .uri(uri)
+                    .retrieve()
+                    .body(BokApiExchangeRateDto.BokApiExchangeRateResponse.class);
+        } catch (RestClientException e) {
+            log.error("Failed to fetch BOK API data: {}", e.getMessage());
+            throw e;
+        }
+    }
+
+    /**
+     * URI 생성
+     */
+    private String buildUri(StatisticCode statCode, String itemCode, LocalDate startDate, LocalDate endDate) {
+        return String.format(
+                "/StatisticSearch/%s/json/kr/1/1/%s/%s/%s/%s/%s",
+                authKey,
+                statCode.getCode(),
+                statCode.getCycle(),
+                startDate.format(DATE_FORMATTER),
+                endDate.format(DATE_FORMATTER),
+                itemCode
+        );
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/stock/authorization/scheduler/dto/BokApiExchangeRateDto.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/stock/authorization/scheduler/dto/BokApiExchangeRateDto.java
@@ -1,0 +1,72 @@
+package site.tradelink.tradelink.stock.authorization.scheduler.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 한국은행 Open API 환율 응답 DTO
+ */
+public class BokApiExchangeRateDto {
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class BokApiExchangeRateResponse {
+
+        @JsonProperty("StatisticSearch")
+        private StatisticSearch statisticSearch;
+
+        @JsonProperty("RESULT")
+        private Result result;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class StatisticSearch {
+
+        @JsonProperty("list_total_count")
+        private Integer listTotalCount;
+
+        @JsonProperty("row")
+        private List<Row> rows;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Row {
+
+        @JsonProperty("STAT_CODE")
+        private String statCode;
+
+        @JsonProperty("STAT_NAME")
+        private String statName;
+
+        @JsonProperty("ITEM_CODE1")
+        private String itemCode1;
+
+        @JsonProperty("ITEM_NAME1")
+        private String itemName1;
+
+        @JsonProperty("DATA_VALUE")
+        private String dataValue;
+
+        @JsonProperty("TIME")
+        private String time;
+
+        @JsonProperty("UNIT_NAME")
+        private String unitName;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Result {
+
+        @JsonProperty("CODE")
+        private String code;
+
+        @JsonProperty("MESSAGE")
+        private String message;
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/stock/authorization/scheduler/enums/Currency.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/stock/authorization/scheduler/enums/Currency.java
@@ -1,0 +1,29 @@
+package site.tradelink.tradelink.stock.authorization.scheduler.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 통화 코드
+ */
+@Getter
+@RequiredArgsConstructor
+public enum Currency {
+
+    // 미국 달러
+    USD("0000001"),
+
+    // 일본 엔
+    JPY("0000002"),
+
+    // 유로
+    EUR("0000003"),
+
+    // 영국 파운드
+    GBP("0000012"),
+
+    // 중국 위안
+    CNY("0000053");
+
+    private final String itemCode; // 한국은행 API ITEM_CODE1
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/stock/authorization/scheduler/enums/StatisticCode.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/stock/authorization/scheduler/enums/StatisticCode.java
@@ -1,0 +1,18 @@
+package site.tradelink.tradelink.stock.authorization.scheduler.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 한국은행 통계표 코드
+ */
+@Getter
+@RequiredArgsConstructor
+public enum StatisticCode {
+
+    // 주요국 통화의 대원화환율 (3.1.1.1)
+    EXCHANGE_RATE("731Y001", "D");
+
+    private final String code;    // 통계표코드
+    private final String cycle;   // 주기 (D: 일별)
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/stock/authorization/scheduler/validate/BokApiErrorCode.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/stock/authorization/scheduler/validate/BokApiErrorCode.java
@@ -1,0 +1,36 @@
+package site.tradelink.tradelink.stock.authorization.scheduler.validate;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BokApiErrorCode {
+
+    INFO_100("INFO-100", "Invalid auth key"),
+    INFO_200("INFO-200", "No data"),
+
+    ERROR_100("ERROR-100", "Missing required value"),
+    ERROR_101("ERROR-101", "Invalid date format"),
+    ERROR_200("ERROR-200", "Invalid file type"),
+    ERROR_300("ERROR-300", "Missing row count"),
+    ERROR_301("ERROR-301", "Invalid row count type"),
+    ERROR_400("ERROR-400", "Timeout"),
+    ERROR_500("ERROR-500", "Server error"),
+    ERROR_600("ERROR-600", "DB connection error"),
+    ERROR_601("ERROR-601", "SQL error"),
+    ERROR_602("ERROR-602", "Rate limit exceeded");
+
+    private final String code;
+    private final String message;
+
+    public static BokApiErrorCode from(String code) {
+        for (BokApiErrorCode value : BokApiErrorCode.values()) {
+            if (value.getCode().equals(code)) {
+                return value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/stock/authorization/scheduler/validate/BokApiResponseValidator.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/stock/authorization/scheduler/validate/BokApiResponseValidator.java
@@ -1,0 +1,53 @@
+package site.tradelink.tradelink.stock.authorization.scheduler.validate;
+
+import org.springframework.stereotype.Component;
+import site.tradelink.tradelink.stock.authorization.scheduler.dto.BokApiExchangeRateDto;
+
+/**
+ * 한국은행 API 응답 검증
+ * 추후 error 작업 진행
+ */
+@Component
+public class BokApiResponseValidator {
+
+    /**
+     * 응답 유효성 검증
+     */
+    public void validate (BokApiExchangeRateDto.BokApiExchangeRateResponse response) {
+        if (response == null) {
+            throw new IllegalStateException("BOK API response is null");
+        }
+
+        // 실패 응답 처리
+        if (response.getResult() != null) {
+            String codeValue = response.getResult().getCode();
+            String message = response.getResult().getMessage();
+
+            BokApiErrorCode code = BokApiErrorCode.from(codeValue);
+
+            if (code == null) {
+                throw new IllegalStateException("Unknown BOK API result: " + codeValue);
+            }
+
+            switch (code) {
+                // 데이터 없음
+                case INFO_200 -> throw new IllegalStateException("No exchange rate data");
+
+                // 인증 문제
+                case INFO_100 -> throw new IllegalStateException("Invalid BOK API auth key");
+
+                // 요청 파라미터 문제
+                case ERROR_100, ERROR_101, ERROR_200, ERROR_300, ERROR_301 ->
+                        throw new IllegalStateException("Invalid BOK API request: " + message);
+
+                // 재시도 대상
+                case ERROR_400, ERROR_602 ->
+                        throw new IllegalStateException("Temporary BOK API issue: " + message);
+
+                // 외부 시스템 장애
+                case ERROR_500, ERROR_600, ERROR_601 ->
+                        throw new IllegalStateException("BOK API server error: " + message);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- RestClient를 사용한 한국은행(BOK) Open API 클라이언트 구현
- JdkClientHttpRequestFactory의 SimpleAsyncTaskExecutor 폴백 문제 방어
- HttpClient에 명시적 VirtualThreadPerTaskExecutor 주입
- API 응답 검증기(Validator) 추가