### PR TITLE
feat: like controller 추가 및 특정 게시글 좋아요 상태 조회 최적화-#30

### DIFF
--- a/tradelink/src/main/java/site/tradelink/tradelink/like/controller/LikeAuthController.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/like/controller/LikeAuthController.java
@@ -1,0 +1,41 @@
+package site.tradelink.tradelink.like.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import site.tradelink.tradelink.like.request.LikePostDto;
+import site.tradelink.tradelink.like.response.LikePostResponseDto;
+import site.tradelink.tradelink.like.service.LikeCommandService;
+import site.tradelink.tradelink.like.service.LikeQueryService;
+import site.tradelink.tradelink.supports.request.ApiResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth/likes")
+public class LikeAuthController {
+
+    private final LikeCommandService likeCommandService;
+    private final LikeQueryService likeQueryService;
+
+    /**
+     * 좋아요 / 좋아요 취소 이벤트 적재
+     */
+    @PostMapping
+    public ApiResponse<LikePostResponseDto> batchLike(@AuthenticationPrincipal Long memberSeq, @RequestBody @Valid LikePostDto request) {
+        LikePostResponseDto response = likeCommandService.processBatchLikePostEvents(memberSeq, request);
+        return ApiResponse.ok(response);
+    }
+
+    /**
+     * 내가 좋아요한 게시글 목록 조회
+     */
+    @GetMapping("/me")
+    public ApiResponse<Page<Long>> getMyLikedPosts(@AuthenticationPrincipal Long memeberSeq, @PageableDefault Pageable pageable) {
+        Page<Long> response = likeQueryService.getMyLikedPostSeqs(memeberSeq, pageable);
+        return ApiResponse.ok(response);
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/like/controller/LikeController.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/like/controller/LikeController.java
@@ -1,0 +1,28 @@
+package site.tradelink.tradelink.like.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import site.tradelink.tradelink.like.response.LikeStatusResponseDto;
+import site.tradelink.tradelink.like.service.LikeQueryService;
+import site.tradelink.tradelink.supports.request.ApiResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/likes")
+public class LikeController {
+
+    private final LikeQueryService likeQueryService;
+
+    /**
+     * 특정 게시글 좋아요 상태 조회 (게시글 상세용)
+     */
+    @GetMapping("/posts/{postSeq}")
+    public ApiResponse<LikeStatusResponseDto> getLikeStatus(@AuthenticationPrincipal Long memberSeq, @PathVariable Long postSeq) {
+        LikeStatusResponseDto response = likeQueryService.getLikeStatus(memberSeq, postSeq);
+        return ApiResponse.ok(response);
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/like/service/LikeQueryService.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/like/service/LikeQueryService.java
@@ -25,9 +25,13 @@ public class LikeQueryService {
      * 2. 총 좋아요 개수 (숫자 표기용)
      */
     public LikeStatusResponseDto getLikeStatus(Long memberSeq, Long postSeq) {
-        Boolean isLiked = likeStatusRepository.findByMemberSeqAndPostSeq(memberSeq, postSeq)
-                .map(LikeStatus::getIsLiked)
-                .orElse(false);
+        Boolean isLiked = false;
+
+        if (memberSeq != null) {
+            isLiked = likeStatusRepository.findByMemberSeqAndPostSeq(memberSeq, postSeq)
+                    .map(LikeStatus::getIsLiked)
+                    .orElse(false);
+        }
 
         Long likeCount = getPostLikeCount(postSeq);
         return LikeStatusResponseDto.of(postSeq, isLiked, likeCount);


### PR DESCRIPTION
- 기존 특정 게시글 좋아요 상태 조회 시 다음의 어떤 경우라도 query가 한 번 발생하였음
- (로그인 한 경우 or 로그인 하지 않은 경우)
- but, 로그인을 안한 경우에는 특정 게시글 좋아요 상태를 조회하지 않아도 됨. 따라서 조건 분기문을 추가하여 최적화