### PR TITLE
feat: like 도메인 엔티티 인덱스 추가-#42

### DIFF
--- a/tradelink/src/main/java/site/tradelink/tradelink/like/common/scheduler/ProcessLikeEvents.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/like/common/scheduler/ProcessLikeEvents.java
@@ -3,7 +3,6 @@ package site.tradelink.tradelink.like.common.scheduler;
 import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import site.tradelink.tradelink.like.common.enums.ActionType;

--- a/tradelink/src/main/java/site/tradelink/tradelink/like/common/scheduler/failed/DLQRetryScheduler.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/like/common/scheduler/failed/DLQRetryScheduler.java
@@ -1,7 +1,6 @@
 package site.tradelink.tradelink.like.common.scheduler.failed;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import site.tradelink.tradelink.like.entity.LikePostEvent;

--- a/tradelink/src/main/java/site/tradelink/tradelink/like/entity/LikeStatus.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/like/entity/LikeStatus.java
@@ -9,7 +9,14 @@ import site.tradelink.tradelink.supports.entity.BaseEntity;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Table(uniqueConstraints = @UniqueConstraint(name = "uk_member_post", columnNames = {"member_seq", "post_seq"}))
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_member_post", columnNames = {"member_seq", "post_seq"})
+        },
+        indexes = {
+                @Index(name = "idx_like_status_member_time", columnList = "member_seq, modified_time DESC")
+        }
+)
 public class LikeStatus extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/tradelink/src/main/java/site/tradelink/tradelink/like/entity/PostStats.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/like/entity/PostStats.java
@@ -9,6 +9,11 @@ import site.tradelink.tradelink.supports.entity.BaseEntity;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(
+        indexes = {
+                @Index(name = "idx_post_stats_post_seq", columnList = "post_seq")
+        }
+)
 public class PostStats extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/tradelink/src/main/java/site/tradelink/tradelink/like/entity/ProcessorOffset.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/like/entity/ProcessorOffset.java
@@ -9,6 +9,11 @@ import site.tradelink.tradelink.supports.entity.BaseEntity;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(
+        indexes = {
+                @Index(name = "idx_processor_offset_name", columnList = "processor_name")
+        }
+)
 public class ProcessorOffset extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/tradelink/src/main/java/site/tradelink/tradelink/like/entity/failed/LikeEventDLQ.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/like/entity/failed/LikeEventDLQ.java
@@ -5,6 +5,17 @@ import lombok.*;
 import site.tradelink.tradelink.supports.entity.BaseEntity;
 import site.tradelink.tradelink.like.common.enums.ActionType;
 
+/**
+ * DLQ 테이블 특성상 인덱스 미적용
+ * - 정상 시스템에서 데이터 극소량 → 풀 스캔 비용 무의미
+ * - INSERT/DELETE 시 인덱스 유지 비용이 조회 이득보다 큼
+ * - RETRY_BATCH_SIZE = 10으로 처리량 자체가 적음
+ *
+ * @Version 기반 낙관적 락 검토 후 미적용 결정
+ * - ProcessLikeEvents(1초)와 DLQRetryScheduler(60초) 동시 접근 확률 매우 낮음
+ * - 충돌 발생 시 최악의 결과가 retryCount 1 오차로 시스템 장애로 이어지지 않음
+ * - 도입 시 트랜잭션 분리 및 별도 빈 생성 필요로 복잡도 대비 실익 없음
+ */
 @Entity
 @Getter
 @Builder

--- a/tradelink/src/main/java/site/tradelink/tradelink/like/repository/PostStatsRepository.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/like/repository/PostStatsRepository.java
@@ -14,8 +14,5 @@ import java.util.Optional;
 public interface PostStatsRepository extends JpaRepository<PostStats, Long> {
     Optional<PostStats> findByPostSeq(Long postSeq);
 
-    @Query("SELECT ps FROM PostStats ps WHERE ps.postSeq IN :postSeqs")
-    List<PostStats> findAllByPostSeqs(@Param("postSeqs") List<Long> postSeqs);
-
     List<PostStats> findAllByPostSeqIn(Collection<Long> postSeqs);
 }

--- a/tradelink/src/main/java/site/tradelink/tradelink/like/repository/failed/LikeEventDLQRepository.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/like/repository/failed/LikeEventDLQRepository.java
@@ -17,5 +17,4 @@ public interface LikeEventDLQRepository extends JpaRepository<LikeEventDLQ, Long
     @Query("SELECT d FROM LikeEventDLQ d WHERE d.retryCount < :maxRetry ORDER BY d.seq ASC")
     List<LikeEventDLQ> findRetryableEvents(@Param("maxRetry") int maxRetry);
 
-    long countByRetryCountGreaterThanEqual(int retryCount);
 }

--- a/tradelink/src/main/java/site/tradelink/tradelink/supports/config/SchedulerConfig.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/supports/config/SchedulerConfig.java
@@ -55,7 +55,7 @@ public class SchedulerConfig implements SchedulingConfigurer {
         return args -> {
             likeScheduler.scheduleWithFixedDelay(
                     processLikeEvents::processLikeEvents,
-                    Duration.ofMillis(5000)
+                    Duration.ofMillis(1000)
             );
             dlqScheduler.scheduleWithFixedDelay(
                     dlqRetryScheduler::retryFailedEvents,


### PR DESCRIPTION
- LikeStatus: (member_seq, post_seq) 복합 인덱스 추가
  - Change Buffer 활용을 위해 Unique 대신 일반 인덱스로 설정
  - 단일 스레드 스케줄러 보장으로 동시성 이슈 없음
- LikeStatus: (member_seq, modified_time DESC) 복합 인덱스 추가
  - 내 좋아요 목록 조회 성능 개선
- PostStats: (post_seq) 인덱스 추가
  - 단건 조회 및 IN 쿼리 성능 개선
- ProcessorOffset: (processor_name) 인덱스 추가

docs: LikeEventDLQ 인덱스 미적용 사유 주석 추가-#42

DLQ 테이블 특성상 인덱스 미적용
- 정상 시스템에서 데이터 극소량 → 풀 스캔 비용 무의미
- INSERT/DELETE 시 인덱스 유지 비용이 조회 이득보다 큼
- RETRY_BATCH_SIZE = 10으로 처리량 자체가 적음

docs: LikeEventDLQ 낙관적 락 미적용 사유 주석 추가-#42

@Version 기반 낙관적 락 검토 후 미적용 결정
- ProcessLikeEvents(1초)와 DLQRetryScheduler(60초) 동시 접근 확률 매우 낮음
- 충돌 발생 시 최악의 결과가 retryCount 1 오차로 시스템 장애로 이어지지 않음
- 도입 시 트랜잭션 분리 및 별도 빈 생성 필요로 복잡도 대비 실익 없음