### PR TITLE
feat: exchangeRate 도메인 엔티티 인덱스 추가-#43

### DIFF
--- a/tradelink/src/main/java/site/tradelink/tradelink/stock/entity/DailyExchangeRate.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/stock/entity/DailyExchangeRate.java
@@ -14,6 +14,11 @@ import java.time.LocalDate;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(
+        indexes = {
+                @Index(name = "idx_daily_currency_date", columnList = "currency_code, base_date")
+        }
+)
 public class DailyExchangeRate extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/tradelink/src/main/java/site/tradelink/tradelink/stock/entity/ExchangeRate.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/stock/entity/ExchangeRate.java
@@ -14,6 +14,11 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(
+        indexes = {
+                @Index(name = "idx_history_currency_datetime", columnList = "currency_code, base_date_time")
+        }
+)
 public class ExchangeRate extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
- DailyExchangeRate: (currency_code, base_date) 복합 인덱스 추가
- ExchangeRate: (currency_code, base_date_time) 복합 인덱스 추가
  - 차트 조회 시 통화별 시간 범위 검색 최적화
  - 등호 조건(currency_code) 우선, 범위 조건(base_date_time) 후순위 배치
  - 10년 후 48만 건 데이터에서도 30건만 스캔하도록 설계
  - ASC 인덱스로 양방향 스캔 지원 (ORDER BY ASC/DESC 모두 커버)

만약 (base_date, currency_code)로 복합 인덱스를 추가하였을 경우 base_date는 작업 범위를 결정하는 조건이지만,  currency_code는 체크 조건이 되게 됨. 비록 base_date이 currency_code보다 상대적으로 선택도가 높지만, 위와 같은 인덱스 설계는 적절하지 않음