### PR TITLE
refactor: uploadFiles fetch join 제거 및 조회/삭제 쿼리 구조 개선-#44

### DIFF
--- a/tradelink/src/main/java/site/tradelink/tradelink/post/common/scheduler/FileDeletionTransactionalService.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/common/scheduler/FileDeletionTransactionalService.java
@@ -33,11 +33,20 @@ public class FileDeletionTransactionalService {
             return Collections.emptyList();
         }
 
+        List<Long> postSeqs = postsToPurge.stream()
+                .map(Post::getSeq)
+                .toList();
+
+        // batch_fetch_size 설정으로 자동으로 IN 쿼리 실행
         List<String> s3KeysToPurge = postsToPurge.stream()
                 .flatMap(post -> post.getUploadFiles().stream())
                 .map(UploadFile::getS3Key)
                 .toList();
 
+        // UploadFile 먼저 IN 쿼리로 삭제 → orphanRemoval 동작 안 하도록 선제 처리
+        uploadFileRepository.deleteByPostSeqIn(postSeqs);
+
+        // Post 배치 삭제
         postRepository.deleteAllInBatch(postsToPurge);
 
         return s3KeysToPurge;

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/repository/PostRepository.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/repository/PostRepository.java
@@ -17,32 +17,21 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     // 게시글 상세 조회
     @Query("""
-            SELECT DISTINCT p FROM Post p
+            SELECT p FROM Post p
             JOIN FETCH p.member
-            LEFT JOIN FETCH p.uploadFiles
             WHERE p.seq = :postSeq
             AND p.status = 'ACTIVE'
             """)
     Optional<Post> findActivePostWithDetailsBySeq(@Param("postSeq") Long postSeq);
 
-    // 수정용 조회
-    @Query("""
-            SELECT DISTINCT p FROM Post p
-            LEFT JOIN FETCH p.uploadFiles
-            WHERE p.seq = :postSeq
-            AND p.member.seq = :memberSeq
-            AND p.status = 'ACTIVE'
-            """)
-    Optional<Post> findActivePostWithFilesBySeqAndMemberSeq(@Param("postSeq") Long poseSeq, @Param("memberSeq") Long memberSeq);
-
-    // 삭제용 조회
+    // 수정용 or post softDelete 전환
     @Query("""
             SELECT p FROM Post p
             WHERE p.seq = :postSeq
             AND p.member.seq = :memberSeq
             AND p.status = 'ACTIVE'
             """)
-    Optional<Post> findActivePostBySeqAndMemberSeq(@Param("postSeq") Long postSeq, @Param("memberSeq")  Long memberSeq);
+    Optional<Post> findActivePostBySeqAndMemberSeq(@Param("postSeq") Long poseSeq, @Param("memberSeq") Long memberSeq);
 
     /**
      * soft-delete된 게시글들 중 특정 시간 이전에 삭제된 것들을 조회
@@ -51,8 +40,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
      * @return List<Post>
      */
     @Query("""
-            SELECT DISTINCT p FROM Post p
-            LEFT JOIN FETCH p.uploadFiles
+            SELECT p FROM Post p
             WHERE p.status = :status
             AND p.deletedTime < :cutoffDate
             """)

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/repository/file/UploadFileRepository.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/repository/file/UploadFileRepository.java
@@ -1,6 +1,7 @@
 package site.tradelink.tradelink.post.repository.file;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import site.tradelink.tradelink.post.common.enums.FileStatus;
@@ -14,16 +15,28 @@ public interface UploadFileRepository extends JpaRepository<UploadFile, Long> {
 
     // 스케줄러용 soft-delete 파일 조회
     @Query("""
-            SELECT f FROM UploadFile f
-            WHERE f.status = :status
-            AND f.deletedTime < :cutoffDate
-            """)
+           SELECT f FROM UploadFile f
+           WHERE f.status = :status
+           AND f.deletedTime < :cutoffDate
+           """)
     List<UploadFile> findByStatusAndDeletedTimeBefore(@Param("status") FileStatus status, @Param("cutoffDate") LocalDateTime cutoffDate);
 
     // 고아 파일 탐지용: S3 키 목록 중 DB에 존재하는 키만 반환
     @Query("""
-            SELECT f.s3Key FROM UploadFile f
-            WHERE f.s3Key IN :s3Keys
-            """)
+           SELECT f.s3Key FROM UploadFile f
+           WHERE f.s3Key IN :s3Keys
+           """)
     Set<String> findExistingS3Keys(@Param("s3Keys")  Set<String> s3Keys);
+
+    // postSeq where절로 조회하는 메서드 추가
+    @Query("""
+           SELECT f FROM UploadFile f
+           WHERE f.post.seq = :postSeq
+           AND f.status = 'ACTIVE'
+           """)
+    List<UploadFile> findByPostSeq(@Param("postSeq") Long postSeq);
+
+    @Modifying
+    @Query("DELETE FROM UploadFile f WHERE f.post.seq IN :postSeqs")
+    void deleteByPostSeqIn(@Param("postSeqs") List<Long> postSeqs);
 }

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/service/PostTransactionalService.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/service/PostTransactionalService.java
@@ -5,10 +5,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.tradelink.tradelink.oauth2.entity.Member;
 import site.tradelink.tradelink.oauth2.repository.MemberRepository;
-import site.tradelink.tradelink.post.common.enums.PostStatus;
 import site.tradelink.tradelink.post.entity.Post;
 import site.tradelink.tradelink.post.entity.UploadFile;
 import site.tradelink.tradelink.post.repository.PostRepository;
+import site.tradelink.tradelink.post.repository.file.UploadFileRepository;
 import site.tradelink.tradelink.post.request.PostCreateDto;
 import site.tradelink.tradelink.post.request.PostUpdateDto;
 import site.tradelink.tradelink.post.response.PostResponseDto;
@@ -24,9 +24,11 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class PostTransactionalService {
 
+    private final FileUrlService fileUrlService;
+
     private final MemberRepository memberRepository;
     private final PostRepository postRepository;
-    private final FileUrlService fileUrlService;
+    private final UploadFileRepository uploadFileRepository;
 
     @Transactional
     public Long createPostAndMetadata(PostCreateDto request, Long memberSeq) {
@@ -59,7 +61,7 @@ public class PostTransactionalService {
         Post post = postRepository.findActivePostWithDetailsBySeq(postSeq)
                 .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
 
-        List<String> imageUrls = post.getUploadFiles().stream()
+        List<String> imageUrls = uploadFileRepository.findByPostSeq(postSeq).stream()
                 .map(file -> fileUrlService.issueDownloadUrl(file.getS3Key()))
                 .toList();
 
@@ -77,18 +79,19 @@ public class PostTransactionalService {
     @Transactional
     public void updatePost(Long postSeq, Long memberSeq, PostUpdateDto updateDto) {
         // 추후 Error 작업 추가
-        Post post = postRepository.findActivePostWithFilesBySeqAndMemberSeq(postSeq, memberSeq)
+        Post post = postRepository.findActivePostBySeqAndMemberSeq(postSeq, memberSeq)
                 .orElseThrow(() -> new IllegalArgumentException("게시글이 없거나 수정 권한이 없습니다."));
 
         post.update(updateDto.getTitle(), updateDto.getContent());
 
         if (updateDto.getS3Keys() != null) {
-            updatePostFiles(post, updateDto.getS3Keys());
+            List<UploadFile> currentFiles = uploadFileRepository.findByPostSeq(postSeq);
+            updatePostFiles(post, currentFiles, updateDto.getS3Keys());
         }
     }
 
-    private void updatePostFiles(Post post, List<String> newS3Keys) {
-        Map<String, UploadFile> existingFilesMap = post.getUploadFiles().stream()
+    private void updatePostFiles(Post post, List<UploadFile> currentFiles, List<String> newS3Keys) {
+        Map<String, UploadFile> existingFilesMap = currentFiles.stream()
                 .collect(Collectors.toMap(UploadFile::getS3Key, file -> file));
 
         Set<String> newKeysSet = new HashSet<>(newS3Keys);


### PR DESCRIPTION
- Post 조회에서 uploadFiles fetch join 제거하고 별도 조회로 분리
- 중복된 Post 조회 메서드 통합
- 스케줄러 조회 쿼리에서 DISTINCT 및 컬렉션 fetch join 제거 (cartesian product 방지)
- UploadFile bulk 삭제용 deleteByPostSeqIn 추가
- soft deleted post purge 로직을 bulk 쿼리 기반으로 리팩토링 (총 3쿼리)