### PR TITLE
feat: Post, UploadFile 엔티티에 쿼리 최적화를 위한 인덱스 추가-#45

### DIFF
--- a/tradelink/src/main/java/site/tradelink/tradelink/post/entity/Post.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/entity/Post.java
@@ -15,6 +15,9 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(indexes = {
+        @Index(name = "idx_post_status_deleted_time", columnList = "status, deleted_time")
+})
 public class Post extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/tradelink/src/main/java/site/tradelink/tradelink/post/entity/UploadFile.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/post/entity/UploadFile.java
@@ -12,6 +12,11 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(indexes = {
+        @Index(name = "idx_upload_file_post_seq", columnList = "post_seq"),
+        @Index(name = "idx_upload_file_status_deleted_time", columnList = "status, deleted_time"),
+        @Index(name = "idx_upload_file_s3_key", columnList = "s3Key")
+})
 public class UploadFile extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
- Post: (status, deletedTime) 복합 인덱스 추가
  - 스케줄러의 soft-delete 게시글 조회 쿼리 최적화

- UploadFile: (post_seq) 인덱스 추가
  - 게시글별 파일 조회 및 벌크 삭제 쿼리 최적화

- UploadFile: (status, deletedTime) 복합 인덱스 추가
  - 스케줄러의 soft-delete 파일 조회 쿼리 최적화

- UploadFile: (s3Key) 인덱스 추가
  - 고아 파일 탐지를 위한 IN절 조회 최적화