### PR TITLE
fix: DLQ 재처리 성공 시 post_stats likeCount 미반영 버그 수정-#48

### DIFF
--- a/tradelink/src/main/java/site/tradelink/tradelink/like/common/scheduler/failed/DLQRetryScheduler.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/like/common/scheduler/failed/DLQRetryScheduler.java
@@ -3,12 +3,18 @@ package site.tradelink.tradelink.like.common.scheduler.failed;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
+import site.tradelink.tradelink.like.common.enums.ActionType;
 import site.tradelink.tradelink.like.entity.LikePostEvent;
+import site.tradelink.tradelink.like.entity.PostStats;
 import site.tradelink.tradelink.like.entity.failed.LikeEventDLQ;
+import site.tradelink.tradelink.like.repository.PostStatsRepository;
 import site.tradelink.tradelink.like.repository.failed.LikeEventDLQRepository;
 import site.tradelink.tradelink.like.service.LikeEventProcessor;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
@@ -17,6 +23,7 @@ public class DLQRetryScheduler {
     private final LikeEventProcessor likeEventProcessor;
 
     private final LikeEventDLQRepository dlqRepository;
+    private final PostStatsRepository postStatsRepository;
 
     private static final int MAX_RETRY_COUNT = 3;
     private static final int RETRY_BATCH_SIZE = 10;
@@ -37,6 +44,8 @@ public class DLQRetryScheduler {
             return;
         }
 
+        Map<Long, Long> postLikeDeltaMap = new HashMap<>();
+
         int successCount = 0;
         int failureCount = 0;
 
@@ -54,6 +63,8 @@ public class DLQRetryScheduler {
                 boolean statusChanged = likeEventProcessor.processSingleLikeStatus(originalEvent);
 
                 if (statusChanged) {
+                    long delta = (dlqEvent.getActionType() == ActionType.LIKE) ? 1L : -1L;
+                    postLikeDeltaMap.merge(dlqEvent.getPostSeq(), delta, Long::sum);
                     //성공하면 DLQ에서 삭제
                     dlqRepository.delete(dlqEvent);
                     successCount++;
@@ -66,5 +77,38 @@ public class DLQRetryScheduler {
                 dlqEvent.incrementRetryCount();
             }
         }
+        
+        updatePostStatsInBatch(postLikeDeltaMap);
+    }
+
+    private void updatePostStatsInBatch(Map<Long, Long> postLikeDeltaMap) {
+        if (postLikeDeltaMap.isEmpty()) {
+            return;
+        }
+
+        List<Long> postSeqs = new ArrayList<>(postLikeDeltaMap.keySet());
+        List<PostStats> statsList = postStatsRepository.findAllByPostSeqIn(postSeqs);
+
+        Map<Long, PostStats> statsMap = new HashMap<>();
+        for (PostStats stats : statsList) {
+            statsMap.put(stats.getPostSeq(), stats);
+        }
+
+        for (Map.Entry<Long, Long> entry : postLikeDeltaMap.entrySet()) {
+            Long  postSeq = entry.getKey();
+            Long delta = entry.getValue();
+
+            PostStats stats = statsMap.get(postSeq);
+            if (stats != null) {
+                stats.setLikeCount(stats.getLikeCount() + delta);
+            } else {
+                statsList.add(PostStats.builder()
+                        .postSeq(postSeq)
+                        .likeCount(Math.max(0, delta))
+                        .build());
+            }
+        }
+
+        postStatsRepository.saveAll(statsList);
     }
 }

--- a/tradelink/src/test/java/site/tradelink/tradelink/post/service/PostTransactionalServiceTest.java
+++ b/tradelink/src/test/java/site/tradelink/tradelink/post/service/PostTransactionalServiceTest.java
@@ -192,7 +192,7 @@ class PostTransactionalServiceTest {
                     .s3Keys(List.of())
                     .build();
 
-            given(postRepository.findActivePostWithFilesBySeqAndMemberSeq(postSeq, memberSeq))
+            given(postRepository.findActivePostBySeqAndMemberSeq(postSeq, memberSeq))
                     .willReturn(Optional.of(post));
 
             // when
@@ -216,7 +216,7 @@ class PostTransactionalServiceTest {
                     .s3Keys(List.of())
                     .build();
 
-            given(postRepository.findActivePostWithFilesBySeqAndMemberSeq(postSeq, memberSeq))
+            given(postRepository.findActivePostBySeqAndMemberSeq(postSeq, memberSeq))
                     .willReturn(Optional.empty());
 
             // when & then


### PR DESCRIPTION
DLQRetryScheduler에서 like_status만 갱신하고 post_stats는 갱신하지 않아 likeCount 불일치 발생

- PostStatsRepository 주입 추가
- 재처리 성공(statusChanged=true) 시 delta 누적
- 배치 루프 종료 후 updatePostStatsInBatch 일괄 반영