### PR TITLE
feat(crypto): 빗썸 WebSocket 실시간 시세/호가 수집 파이프라인 구축-#51

### DIFF
--- a/tradelink/build.gradle
+++ b/tradelink/build.gradle
@@ -70,6 +70,9 @@ dependencies {
 	// Monitoring
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
+
+    // WebSocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
 }
 
 tasks.named('test') {

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/clients/BithumbWebsocketClient.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/clients/BithumbWebsocketClient.java
@@ -1,0 +1,169 @@
+package site.tradelink.tradelink.cryptocurrency.clients;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.*;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import site.tradelink.tradelink.cryptocurrency.handler.BithumbOrderBookHandler;
+import site.tradelink.tradelink.cryptocurrency.handler.BithumbOrderBookSnapshotHandler;
+import site.tradelink.tradelink.cryptocurrency.handler.BithumbTickerHandler;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * 빗썸 WebSocket 클라이언트
+ *
+ * 구독 타입:
+ * - ticker: 현재가 -> BithumbTickerHandler
+ * - orderbooksnapshot: 초기 전체 호가 -> BithumbOrderBookSnapshotHandler
+ * - orderBookDepth: 호가 변경분 -> BithumbOrderBookHandler
+ *
+ * 호가 수신 순서:
+ * 1. 연결 직후 orderbooksnapshot 구독 -> 전체 30호가 수신 -> OrderBookCache 초기화
+ * 2. 이후 orderbookdepth로 변경된 레벨만 수신 -> 부분 업데이트
+ *
+ * 재연결 전략:
+ * - 5회까지 : 지수 백오프 (2s → 4s → 8s → 16s → 30s 상한)
+ * - 5회 초과 : 5분 대기 후 카운터 리셋 → 무한 재시도
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BithumbWebsocketClient implements WebSocketHandler {
+
+    private static final String WS_URL = "wss://pubwss.bithumb.com/pub/ws";
+    private static final int MAX_RECONNECT = 5;
+    private static final long RECONNECT_BASE_MS = 1_000;
+    private static final long   RESET_AFTER_MS    = 5 * 60 * 1_000L;
+
+    // 구독할 심볼 목록 (빗썸 형식: BASE_KRW)
+    private static final List<String> SYMBOLS = List.of(
+            "BTC_KRW", "ETH_KRW", "XRP_KRW", "ADA_KRW",
+            "DOGE_KRW", "LINK_KRW", "TRX_KRW",
+            "LTC_KRW", "BCH_KRW", "ETC_KRW"
+    );
+
+    private final BithumbTickerHandler tickerHandler;
+    private final BithumbOrderBookSnapshotHandler snapshotHandler;
+    private final BithumbOrderBookHandler orderBookHandler;
+    private final ObjectMapper objectMapper;
+
+    private WebSocketSession session;
+    private final AtomicInteger reconnectAttempts = new AtomicInteger(0);
+
+    @PostConstruct
+    public void connect() {
+        connectInternal();
+    }
+
+    // 연결
+    private void connectInternal() {
+        StandardWebSocketClient client = new StandardWebSocketClient();
+
+        client.execute(this, WS_URL) // CompletableFuture<WebSocketSession>
+                .whenComplete((session, ex) -> {
+                    if (ex != null) {
+                        log.error("[Bithumb WS] 연결 실패: {}", ex.getMessage());
+                        scheduleReconnect();
+                    }
+                    // 성공 시 afterConnectionEstablished() 에서 처리
+                });
+    }
+
+    // WebSocketHandler 구현
+
+    @Override
+    public void afterConnectionEstablished(org.springframework.web.socket.WebSocketSession session) throws Exception {
+        reconnectAttempts.set(0);
+        log.info("[Bithumb WS] 연결 성공");
+
+        // 1. 현재가 구독
+        subscribe(session, "ticker");
+
+        // 2. 초기 전체 호가 스냅샷 구독 (연결 직후 1회)
+        subscribe(session, "orderbooksnapshot");
+
+        // 3. 이후 변경분 구독
+        subscribe(session, "orderbookdepth");
+    }
+
+    @Override
+    public void handleMessage(org.springframework.web.socket.WebSocketSession session, WebSocketMessage<?> message) throws Exception {
+        try {
+            String payload = message.getPayload().toString();
+            JsonNode root = objectMapper.readTree(payload);
+            String type = root.path("type").asText();
+
+            switch (type) {
+                case "ticker": tickerHandler.handle(root);
+                case "orderbooksnapshot": snapshotHandler.handle(root);
+                case  "orderbookdepth": orderBookHandler.handle(root);
+                default: log.trace("[Bithumb WS] 미처리 타입: {}", type);
+            }
+        } catch (Exception e) {
+            log.error("[Bithumb WS] 메시지 처리 오류: {}", e.getMessage());
+        }
+    }
+
+    @Override
+    public void handleTransportError(org.springframework.web.socket.WebSocketSession session, Throwable ex) throws Exception {
+        log.error("[Bithumb WS] 전송 오류: {}", ex.getMessage());
+        scheduleReconnect();
+    }
+
+    @Override
+    public void afterConnectionClosed(org.springframework.web.socket.WebSocketSession session, CloseStatus status) throws Exception {
+        log.warn("[Bithumb WS] 연결 종료: {}", status);
+        scheduleReconnect();
+    }
+
+    @Override
+    public boolean supportsPartialMessages() {
+        return false;
+    }
+
+    // 구독
+    private void subscribe(WebSocketSession session, String type) throws IOException {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("type", type);
+        payload.put("symbols", SYMBOLS);
+        if ("ticker".equals(type)) {
+            payload.put("tickTypes", List.of("24H"));
+        }
+        session.sendMessage(new TextMessage(objectMapper.writeValueAsString(payload)));
+        log.info("[Bithumb WS] {} 구독 완료 ({}개 심볼)", type, SYMBOLS.size());
+    }
+
+    // 재연결
+    private void scheduleReconnect() {
+        int attempt = reconnectAttempts.incrementAndGet();
+
+        long delay;
+        if (attempt <= MAX_RECONNECT) {
+            delay = Math.min(RECONNECT_BASE_MS * (1L << attempt), 30_000L);
+            log.info("[Bithumb WS] {}ms 후 재연결 ({}/{})", delay, attempt, MAX_RECONNECT);
+        } else {
+            delay = RESET_AFTER_MS;
+            log.warn("[Bithumb WS] 재연결 한도 초과 → {}분 후 카운터 리셋", RESET_AFTER_MS / 60_000);
+        }
+
+        Thread.startVirtualThread(() -> {
+            try {
+                Thread.sleep(Duration.ofMillis(delay));
+                if (attempt > MAX_RECONNECT) {
+                    reconnectAttempts.set(0);
+                }
+                connectInternal();
+            } catch (InterruptedException ignore) {}
+        });
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/dto/OrderBookDto.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/dto/OrderBookDto.java
@@ -1,0 +1,22 @@
+package site.tradelink.tradelink.cryptocurrency.dto;
+
+import java.util.List;
+
+/**
+ * 호가창 SSE 이벤트 DTO (order-book 채널)
+ *
+ * 빗썸 orderbookdepth 기반
+ * asks : 매도 호가 (index 0 = 최우선 = 가장 낮은 가격)
+ * bids : 매수 호가 (index 0 = 최우선 = 가장 높은 가격)
+ */
+public record OrderBookDto(
+        String ticker,
+        List<OrderBookEntry> asks,
+        List<OrderBookEntry> bids
+) {
+    /**
+     * price    : 호가 (원)
+     * quantity : 잔량 (암호화폐 단위, 소수점 가능)
+     */
+    public record OrderBookEntry(long price, double quantity) {}
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/dto/StockPriceSummaryDto.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/dto/StockPriceSummaryDto.java
@@ -1,0 +1,13 @@
+package site.tradelink.tradelink.cryptocurrency.dto;
+
+import java.time.LocalDateTime;
+
+public record StockPriceSummaryDto(
+    String        ticker,
+    String        name,
+    long          price,         // 현재가 (원)
+    long          changeAmount,  // 전일 대비 변동액
+    double        changePercent, // 전일 대비 변동률 (%)
+    long          volume,        // 누적 거래량
+    LocalDateTime updatedAt
+) {}

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/handler/BithumbOrderBookHandler.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/handler/BithumbOrderBookHandler.java
@@ -1,0 +1,106 @@
+package site.tradelink.tradelink.cryptocurrency.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import site.tradelink.tradelink.cryptocurrency.dto.OrderBookDto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 빗썸 orderbookdepth 메시지 처리 (변경분 업데이트)
+ *
+ * 전제: 연결 직후 orderbooksnapshot으로 초기 호가가 이미 캐시에 있음
+ * -> orderbookdepth는 변경된 호가 레벨만 전송
+ *
+ * 실제 응답 구조:
+ *  {
+ *    "type": "orderbookdepth",
+ *    "content": {
+ *      "list": [
+ *        { "symbol": "BTC_KRW", "orderType": "ask", "price": "10593000", "quantity": "1.11", "total": "3" },
+ *        { "symbol": "BTC_KRW", "orderType": "bid", "price": "10532000", "quantity": "0",    "total": "0" }
+ *      ],
+ *      "datetime": 1580268255864325
+ *    }
+ *  }
+ *
+ * quantity = "0" → 해당 호가 레벨 제거
+ * quantity > 0   → 해당 가격의 잔량 갱신 (없으면 추가, 있으면 교체)
+ *
+ * 처리 후 asks 오름차순 / bids 내림차순 재정렬 → 상위 5단계만 유지
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BithumbOrderBookHandler {
+
+    private static final int DEPTH = 5;
+
+    private final OrderBookCache orderBookCache;
+    private final DirtyTracker dirtyTracker;
+
+    public void handle(JsonNode root) {
+        try {
+            JsonNode list = root.path("content").path("list");
+            if (!list.isArray() || list.isEmpty()) {
+                return;
+            }
+
+            String ticker = list.get(0).path("symbol").asText().replace("_KRW", "");
+
+            // 현재 캐시 호가 가져오기 (snapshot이 없으면 버림)
+            OrderBookDto current = orderBookCache.find(ticker).orElse(null);
+
+            if (current == null) {
+                log.debug("[OrderBook] {} 스냅샷이 아직 없어 변경분을 무시합니다.", ticker);
+                return; // Snapshot이 올 때까지 기다림
+            }
+
+            List<OrderBookDto.OrderBookEntry> asks = new ArrayList<>(current.asks());
+            List<OrderBookDto.OrderBookEntry> bids = new ArrayList<>(current.bids());
+
+            // 변경분 적용
+            for (JsonNode item : list) {
+                String orderType = item.path("orderType").asText(); // "ask" | "bid"
+                long   price     = (long) Double.parseDouble(item.path("price").asText());
+                double quantity  = Double.parseDouble(item.path("quantity").asText());
+
+                List<OrderBookDto.OrderBookEntry> target = "ask".equals(orderType) ? asks : bids;
+                applyUpdate(target, price, quantity);
+            }
+
+            // 재정렬 + 상위 5단계만 유지
+            asks.sort((a, b) -> Long.compare(a.price(), b.price()));  // 오름차순
+            bids.sort((a, b) -> Long.compare(b.price(), a.price()));  // 내림차순
+
+            List<OrderBookDto.OrderBookEntry> trimmedAsks = asks.size() > DEPTH ? asks.subList(0, DEPTH) : asks;
+            List<OrderBookDto.OrderBookEntry> trimmedBids = bids.size() > DEPTH ? bids.subList(0, DEPTH) : bids;
+
+            OrderBookDto updated = new OrderBookDto(ticker, trimmedAsks, trimmedBids);
+
+            if (!updated.equals(current)) {
+                orderBookCache.put(ticker, updated);
+                dirtyTracker.markDirty(ticker);
+            }
+        } catch (Exception e) {
+            log.warn("[OrderBookDepth] 처리 오류: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * 단일 호가 레벨 업데이트
+     * quantity == 0 → 해당 가격 제거
+     * quantity  > 0 → 해당 가격 잔량 갱신 (없으면 추가)
+     */
+    private void applyUpdate(List<OrderBookDto.OrderBookEntry> entries, long price, double quantity) {
+        entries.removeIf(e -> e.price() == price); // 기존 레벨 제거
+
+        if (quantity > 0) {
+            entries.add(new OrderBookDto.OrderBookEntry(price, quantity)); // 새 잔량으로 추가
+        }
+        // quantity == 0 이면 제거만 하고 끝
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/handler/BithumbOrderBookSnapshotHandler.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/handler/BithumbOrderBookSnapshotHandler.java
@@ -1,0 +1,75 @@
+package site.tradelink.tradelink.cryptocurrency.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import site.tradelink.tradelink.cryptocurrency.dto.OrderBookDto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 빗썸 orderbooksnapshot 메시지 처리
+ *
+ * 웹소켓 연결 직후 전체 호가 초기화 이후 변경분은 BitumbOrderBookHandler가 처리
+ *
+ * 실제 응답 구조:
+ * {
+ *   "type": "orderbooksnapshot",
+ *   "content": {
+ *     "symbol": "BTC_KRW",
+ *     "asks": [["37458000","0.9986"], ["37461000","0.0487"]], // [가격, 잔량] 배열
+ *     "bids": [["37452000","0.0115"], ["37450000","0.0614"]]
+ *   }
+ * }
+ *
+ * 상위 5단계만 추출하여 OrderBookCache 초기화
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BithumbOrderBookSnapshotHandler {
+
+    private static final int DEPTH = 5;
+
+    private final OrderBookCache orderBookCache;
+    private final DirtyTracker dirtyTracker;
+
+    public void handle(JsonNode root) {
+        try {
+            JsonNode content = root.path("content");
+            String   symbol  = content.path("symbol").asText();  // "BTC_KRW"
+            String   ticker  = symbol.replace("_KRW", "");       // "BTC"
+
+            List<OrderBookDto.OrderBookEntry> asks = parseArray(content.path("asks"), true);
+            List<OrderBookDto.OrderBookEntry> bids = parseArray(content.path("bids"), false);
+
+            OrderBookDto dto = new OrderBookDto(ticker, asks, bids);
+
+            // 전체 스냅샷으로 캐시 초기화
+            orderBookCache.put(ticker, dto);
+            dirtyTracker.markDirty(ticker);
+        } catch (Exception e) {
+            log.warn("[Snapshot] 처리 오류: {}", e.getMessage());
+        }
+    }
+
+    // 빗썸이 이미 정렬해서 주므로 정렬 불필요
+    private List<OrderBookDto.OrderBookEntry> parseArray(JsonNode node, boolean isAsk) {
+        List<OrderBookDto.OrderBookEntry> entries = new ArrayList<>();
+
+        if (!node.isArray()) return entries;
+
+        for (JsonNode item : node) {
+            if (!item.isArray() || item.size() < 2) continue;
+            long   price = (long) Double.parseDouble(item.get(0).asText());
+            double qty   = Double.parseDouble(item.get(1).asText());
+            if (price > 0 && qty > 0) {
+                entries.add(new OrderBookDto.OrderBookEntry(price, qty));
+            }
+        }
+
+        return entries.size() > DEPTH ? entries.subList(0, DEPTH) : entries;
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/handler/BithumbTickerHandler.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/handler/BithumbTickerHandler.java
@@ -1,0 +1,55 @@
+package site.tradelink.tradelink.cryptocurrency.handler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import site.tradelink.tradelink.cryptocurrency.dto.StockPriceSummaryDto;
+
+import java.time.LocalDateTime;
+
+/**
+ * 빗썸 ticker 메시지 처리
+ *
+ * - StockPriceCache 갱신 후 DirtyTracker.markDirty()만 호출
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BithumbTickerHandler {
+
+    private final StockPriceCache priceCache;
+    private final DirtyTracker dirtyTracker;
+
+    public void handle(JsonNode root) {
+        try {
+            JsonNode content = root.path("content");
+            String symbol = content.path("symbol").asText(); // "BTC_KRW"
+            String ticker = symbol.replace("_KRW", ""); // "BTC"
+
+            long   price      = (long) Double.parseDouble(content.path("closePrice").asText());
+            long   changeAmt  = (long) Double.parseDouble(content.path("chgAmt").asText());
+            double changeRate = Double.parseDouble(content.path("chgRate").asText());
+            long   volume     = (long) Double.parseDouble(content.path("volume").asText());
+
+            StockPriceSummaryDto dto = new StockPriceSummaryDto(
+                    ticker,
+                    CryptoName.of(ticker),
+                    price,
+                    changeAmt,
+                    changeRate,
+                    volume,
+                    LocalDateTime.now()
+            );
+
+            // 1. 캐시 갱신
+            priceCache.putPrice(ticker, dto);
+
+            // 2. dirty 표시
+            dirtyTracker.markDirty(ticker);
+
+        } catch (Exception e) {
+            log.warn("[BithumbTicker] 처리 오류: {}", e.getMessage());
+        }
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/handler/CryptoName.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/handler/CryptoName.java
@@ -1,0 +1,25 @@
+package site.tradelink.tradelink.cryptocurrency.handler;
+
+import java.util.Map;
+
+public final class CryptoName {
+
+    private CryptoName() {}
+
+    private static final Map<String, String> NAMES = Map.ofEntries(
+            Map.entry("BTC",   "비트코인"),
+            Map.entry("ETH",   "이더리움"),
+            Map.entry("XRP",   "리플"),
+            Map.entry("ADA",   "에이다"),
+            Map.entry("DOGE",  "도지코인"),
+            Map.entry("LINK",  "체인링크"),
+            Map.entry("TRX",   "트론"),
+            Map.entry("LTC",   "라이트코인"),
+            Map.entry("BCH",   "비트코인캐시"),
+            Map.entry("ETC",   "이더리움클래식")
+    );
+
+    public static String of(String ticker) {
+        return NAMES.getOrDefault(ticker, ticker);
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/supports/config/JacksonConfig.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/supports/config/JacksonConfig.java
@@ -1,0 +1,18 @@
+package site.tradelink.tradelink.supports.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+    }
+}


### PR DESCRIPTION
[Architecture & Strategy]
- 모의투자 체결 엔진 및 SSE 브로드캐스트의 기반이 되는 실시간 시장 데이터 수집기 구현.
- 호가창(Orderbook) 수신 최적화: 최초 연결 시 `orderbooksnapshot`으로 전체 상태를 로드하고, 이후 `orderbookdepth`로 변경된 호가 레벨(Delta)만 업데이트하여 상위 5호가를 유지함.
- 효율적인 상태 전파를 위해 `DirtyTracker`를 도입하여 변경이 발생한 티커만 추적하도록 설계.

[Changes]
- 빗썸 퍼블릭 WebSocket 클라이언트(`BithumbWebsocketClient`) 구현
- 메시지 타입별 전용 핸들러 분리 (`Ticker`, `OrderBookSnapshot`, `OrderBook`)
- 네트워크 불안정 대비 지수 백오프(Exponential Backoff) 기반 재연결 로직 구현 (Virtual Thread 활용)