### PR TITLE
feat(crypto): 호가/시세 캐시 동시성 최적화 및 SSE 브로드캐스팅 기반 마련-#53

### DIFF
--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/dto/TradeLogDto.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/dto/TradeLogDto.java
@@ -1,0 +1,14 @@
+package site.tradelink.tradelink.cryptocurrency.dto;
+
+import java.time.LocalDateTime;
+
+/**
+ * 체결내역 SSE 이벤트 DTO
+ */
+public record TradeLogDto (
+        String        ticker,
+        long          price,        // 체결가
+        long          quantity,     // 체결량
+        String        side,         // "BUY" | "SELL"
+        LocalDateTime tradedAt
+) {}

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/handler/BithumbOrderBookHandler.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/handler/BithumbOrderBookHandler.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import site.tradelink.tradelink.cryptocurrency.dto.OrderBookDto;
+import site.tradelink.tradelink.cryptocurrency.inMemory.DirtyTracker;
+import site.tradelink.tradelink.cryptocurrency.inMemory.OrderBookCache;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,56 +53,29 @@ public class BithumbOrderBookHandler {
 
             String ticker = list.get(0).path("symbol").asText().replace("_KRW", "");
 
-            // 현재 캐시 호가 가져오기 (snapshot이 없으면 버림)
-            OrderBookDto current = orderBookCache.find(ticker).orElse(null);
-
-            if (current == null) {
-                log.debug("[OrderBook] {} 스냅샷이 아직 없어 변경분을 무시합니다.", ticker);
-                return; // Snapshot이 올 때까지 기다림
+            // snapshot 없으면 명시적으로 무시
+            if (orderBookCache.find(ticker).isEmpty()) {
+                log.debug("[OrderBookDepth] {} 스냅샷 미수신, 변경분 무시", ticker);
+                return;
             }
 
-            List<OrderBookDto.OrderBookEntry> asks = new ArrayList<>(current.asks());
-            List<OrderBookDto.OrderBookEntry> bids = new ArrayList<>(current.bids());
-
-            // 변경분 적용
+            List<OrderBookCache.DepthUpdate> updates = new ArrayList<>();
             for (JsonNode item : list) {
-                String orderType = item.path("orderType").asText(); // "ask" | "bid"
-                long   price     = (long) Double.parseDouble(item.path("price").asText());
-                double quantity  = Double.parseDouble(item.path("quantity").asText());
-
-                List<OrderBookDto.OrderBookEntry> target = "ask".equals(orderType) ? asks : bids;
-                applyUpdate(target, price, quantity);
+                updates.add(new OrderBookCache.DepthUpdate(
+                        item.path("orderType").asText(),
+                        (long) Double.parseDouble(item.path("price").asText()),
+                        Double.parseDouble(item.path("quantity").asText())
+                ));
             }
 
-            // 재정렬 + 상위 5단계만 유지
-            asks.sort((a, b) -> Long.compare(a.price(), b.price()));  // 오름차순
-            bids.sort((a, b) -> Long.compare(b.price(), a.price()));  // 내림차순
-
-            List<OrderBookDto.OrderBookEntry> trimmedAsks = asks.size() > DEPTH ? asks.subList(0, DEPTH) : asks;
-            List<OrderBookDto.OrderBookEntry> trimmedBids = bids.size() > DEPTH ? bids.subList(0, DEPTH) : bids;
-
-            OrderBookDto updated = new OrderBookDto(ticker, trimmedAsks, trimmedBids);
-
-            if (!updated.equals(current)) {
-                orderBookCache.put(ticker, updated);
+            // 실제 변경 발생 시에만 dirty 표시 -> 불필요한 SSE broadcast 방지
+            boolean changed = orderBookCache.merge(ticker, updates);
+            if (changed) {
                 dirtyTracker.markDirty(ticker);
             }
+
         } catch (Exception e) {
             log.warn("[OrderBookDepth] 처리 오류: {}", e.getMessage());
         }
-    }
-
-    /**
-     * 단일 호가 레벨 업데이트
-     * quantity == 0 → 해당 가격 제거
-     * quantity  > 0 → 해당 가격 잔량 갱신 (없으면 추가)
-     */
-    private void applyUpdate(List<OrderBookDto.OrderBookEntry> entries, long price, double quantity) {
-        entries.removeIf(e -> e.price() == price); // 기존 레벨 제거
-
-        if (quantity > 0) {
-            entries.add(new OrderBookDto.OrderBookEntry(price, quantity)); // 새 잔량으로 추가
-        }
-        // quantity == 0 이면 제거만 하고 끝
     }
 }

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/handler/BithumbOrderBookSnapshotHandler.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/handler/BithumbOrderBookSnapshotHandler.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import site.tradelink.tradelink.cryptocurrency.dto.OrderBookDto;
+import site.tradelink.tradelink.cryptocurrency.inMemory.DirtyTracker;
+import site.tradelink.tradelink.cryptocurrency.inMemory.OrderBookCache;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,8 +32,6 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class BithumbOrderBookSnapshotHandler {
-
-    private static final int DEPTH = 5;
 
     private final OrderBookCache orderBookCache;
     private final DirtyTracker dirtyTracker;
@@ -62,14 +62,18 @@ public class BithumbOrderBookSnapshotHandler {
         if (!node.isArray()) return entries;
 
         for (JsonNode item : node) {
-            if (!item.isArray() || item.size() < 2) continue;
-            long   price = (long) Double.parseDouble(item.get(0).asText());
-            double qty   = Double.parseDouble(item.get(1).asText());
+            if (!item.isArray() || item.size() < 2) {
+                continue;
+            }
+
+            long price = (long) Double.parseDouble(item.get(0).asText());
+            double qty = Double.parseDouble(item.get(1).asText());
+
             if (price > 0 && qty > 0) {
                 entries.add(new OrderBookDto.OrderBookEntry(price, qty));
             }
         }
 
-        return entries.size() > DEPTH ? entries.subList(0, DEPTH) : entries;
+        return entries;
     }
 }

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/handler/BithumbTickerHandler.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/handler/BithumbTickerHandler.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import site.tradelink.tradelink.cryptocurrency.dto.StockPriceSummaryDto;
+import site.tradelink.tradelink.cryptocurrency.inMemory.DirtyTracker;
+import site.tradelink.tradelink.cryptocurrency.inMemory.StockPriceCache;
 
 import java.time.LocalDateTime;
 

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/inMemory/DirtyTracker.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/inMemory/DirtyTracker.java
@@ -1,0 +1,32 @@
+package site.tradelink.tradelink.cryptocurrency.inMemory;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 변경된 종목 추적기
+ *
+ * 빗썸 데이터 수신 / 체결 완료 시 ticker를 dirty로 표시
+ * SnapshotScheduler가 1초마다 dirty 목로을 가져가서 SSE broadcast
+ */
+@Component
+public class DirtyTracker {
+
+    private final Set<String> dirty = ConcurrentHashMap.newKeySet();
+
+    public void markDirty(String ticker) {
+        dirty.add(ticker);
+    }
+
+    public Set<String> getAndClear() {
+        Set<String> snapshot = ConcurrentHashMap.newKeySet();
+        dirty.forEach(ticker -> {
+            if (dirty.remove(ticker)) {
+                snapshot.add(ticker);
+            }
+        });
+        return snapshot;
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/inMemory/OrderBookCache.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/inMemory/OrderBookCache.java
@@ -1,0 +1,169 @@
+package site.tradelink.tradelink.cryptocurrency.inMemory;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import site.tradelink.tradelink.cryptocurrency.dto.OrderBookDto;
+
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 주식 호가 인메모리 캐시
+ * 30호가 전체 보관
+ * 클라이언트(SSE): findTop5()로 상위 5단계만 잘라서 전송
+ */
+@Slf4j
+@Component
+public class OrderBookCache {
+
+    private static final int SSE_DEPTH = 5;
+
+    @Value("${stock.orderbook.stale-ttl-ms:5000}")
+    private long staleTtlMs;
+
+    // 호가 + 수신 시각을 하나로 묶어 원자적 업데이트
+    private record CachedOrderBook(OrderBookDto bookDto, Instant receivedAt) {}
+
+    public record DepthUpdate(String orderType, long price, double quantity) {}
+
+    private final Map<String, CachedOrderBook> cache = new ConcurrentHashMap<>();
+
+    // snapshot 수신 시 전체 교체
+    public void put(String ticker, OrderBookDto orderBook) {
+        cache.put(ticker, new CachedOrderBook(orderBook, Instant.now()));
+    }
+
+    // 내부 전체 호가 조회
+    public Optional<OrderBookDto> find(String ticker) {
+        return Optional.ofNullable(cache.get(ticker))
+                .map(CachedOrderBook::bookDto);
+    }
+
+    // SSE broadcast 용: 상위 5단계만 잘라서 반환
+    public Optional<OrderBookDto> findTop5(String ticker) {
+        return Optional.ofNullable(cache.get(ticker))
+                .map(cache -> {
+                    List<OrderBookDto.OrderBookEntry> asks = cache.bookDto.asks();
+                    List<OrderBookDto.OrderBookEntry> bids = cache.bookDto.bids();
+
+                    return new OrderBookDto(
+                            ticker,
+                            asks.size() > SSE_DEPTH ? asks.subList(0, SSE_DEPTH) : asks,
+                            bids.size() > SSE_DEPTH ? bids.subList(0, SSE_DEPTH) : bids
+                    );
+                });
+    }
+
+    // orderbookdepth 변경분 / 실제 변경이 발생한 경우에만 true 반환 -> dirty 표시 여부 결정
+    public boolean merge(String ticker, List<DepthUpdate> updates) {
+        boolean[] changed = {false};
+
+        cache.computeIfPresent(ticker, (k, cached) -> {
+            List<OrderBookDto.OrderBookEntry> asks = new ArrayList<>(cached.bookDto().asks());
+            List<OrderBookDto.OrderBookEntry> bids = new ArrayList<>(cached.bookDto().bids());
+
+            for (DepthUpdate update : updates) {
+                List<OrderBookDto.OrderBookEntry> target = "ask".equals(update.orderType()) ? asks : bids;
+                boolean updated = applyUpdate(target, update.price(), update.quantity());
+                if (updated) changed[0] = true;
+            }
+
+            if (!changed[0]) return cached; // 변경 없으면 기존 그대로 반환
+
+            asks.sort((a, b) -> Long.compare(a.price(), b.price()));
+            bids.sort((a, b) -> Long.compare(b.price(), a.price()));
+
+            // 30호가 전체 보관 (자르지 않음)
+            OrderBookDto merged = new OrderBookDto(ticker,
+                    new ArrayList<>(asks),
+                    new ArrayList<>(bids));
+
+            return new CachedOrderBook(merged, Instant.now());
+        });
+
+        return changed[0];
+    }
+
+    // 체결가 조회 (stale 체크 포함 / stale 상태면 empty 반환 -> 주문 거부
+    public OptionalLong getBestPrice(String ticker, String side) {
+        if (isStale(ticker)) {
+            log.warn("[OrderBookCache] {} 호가 stale ({}ms 초과)", ticker, staleTtlMs);
+            return OptionalLong.empty();
+        }
+
+        CachedOrderBook cached = cache.get(ticker);
+        if (cached == null) {
+            return OptionalLong.empty();
+        }
+
+        List<OrderBookDto.OrderBookEntry> levels = "BUY".equals(side) ? cached.bookDto.asks() : cached.bookDto.bids();
+
+        if (levels == null || levels.isEmpty()) {
+            return OptionalLong.empty();
+        }
+        return OptionalLong.of(levels.get(0).price());
+    }
+
+    public boolean isStale(String ticker) {
+        CachedOrderBook cached = cache.get(ticker);
+
+        if (cached == null) return true;
+
+        return Instant.now().toEpochMilli() - cached.receivedAt().toEpochMilli() > staleTtlMs;
+    }
+
+    public Optional<Instant> getReceivedAt(String ticker) {
+        return Optional.ofNullable(cache.get(ticker))
+                .map(CachedOrderBook::receivedAt);
+    }
+
+    // 체결 후 잔량 차감
+    public void consume(String ticker, String side, long price, double quantity) {
+        cache.computeIfPresent(ticker, (k, cached) -> {
+            List<OrderBookDto.OrderBookEntry> original = "BUY".equals(side)
+                    ? cached.bookDto().asks()
+                    : cached.bookDto().bids();
+
+            if (original == null || original.isEmpty()) return cached;
+
+            List<OrderBookDto.OrderBookEntry> updated = new ArrayList<>();
+            for (OrderBookDto.OrderBookEntry entry : original) {
+                if (entry.price() == price) {
+                    double remaining = entry.quantity() - quantity;
+                    if (remaining > 0) updated.add(new OrderBookDto.OrderBookEntry(entry.price(), remaining));
+                } else {
+                    updated.add(entry);
+                }
+            }
+
+            OrderBookDto updatedBook = "BUY".equals(side)
+                    ? new OrderBookDto(ticker, updated, cached.bookDto().bids())
+                    : new OrderBookDto(ticker, cached.bookDto().asks(), updated);
+
+            return new CachedOrderBook(updatedBook, cached.receivedAt());
+        });
+    }
+
+
+    /**
+     * 내부 유틸
+     * 단일 호가 레벨 업데이트
+     * quantity == 0 -> 제거
+     * quantitiy > 0 -> 잔량 교체
+     *
+     * 반환: 실제 변경 발생 여부
+     */
+    private boolean applyUpdate(List<OrderBookDto.OrderBookEntry> entries, long price, double quantity) {
+        boolean existed = entries.removeIf(e -> e.price() == price);
+
+        if (quantity > 0) {
+            entries.add(new OrderBookDto.OrderBookEntry(price, quantity));
+            return true;
+        }
+
+        return existed; // quantity==0 이면 제거됐을 때만 변경으로 간주
+    }
+
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/inMemory/StockPriceCache.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/inMemory/StockPriceCache.java
@@ -1,0 +1,65 @@
+package site.tradelink.tradelink.cryptocurrency.inMemory;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import site.tradelink.tradelink.cryptocurrency.dto.StockPriceSummaryDto;
+import site.tradelink.tradelink.cryptocurrency.dto.TradeLogDto;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * 주식 시세 인메모리 캐시
+ * 현재가 + 체결내역 담당
+ */
+@Slf4j
+@Component
+public class StockPriceCache {
+
+    private static final int MAX_TRADE_LOG = 50;
+
+    // 현재가 캐시
+    private final Map<String, StockPriceSummaryDto> priceCache = new ConcurrentHashMap<>();
+
+    // 체결내역 캐시 (종목별 최근 50건)
+    private final Map<String, LinkedList<TradeLogDto>> tradeLogCache = new ConcurrentHashMap<>();
+
+    // 현재가
+    public Optional<StockPriceSummaryDto> findPrice(String ticker) {
+        return Optional.ofNullable(priceCache.get(ticker));
+    }
+
+    public Collection<StockPriceSummaryDto> findAllPrices() {
+        return Collections.unmodifiableCollection(priceCache.values());
+    }
+
+    public void putPrice(String ticker, StockPriceSummaryDto dto) {
+        priceCache.put(ticker, dto);
+    }
+
+    /**
+     * 체결내역
+     * 체결 발생 시 앞에 추가 (최신순 유지) MAX_TRADE_LOG 초과 시 가장 오래된 항목 제거
+     */
+    public void addTradeLog(String ticker, TradeLogDto log) {
+        LinkedList<TradeLogDto> list = tradeLogCache.computeIfAbsent(ticker, k -> new LinkedList<>());
+
+        synchronized (list) {
+            list.addFirst(log);
+            if (list.size() > MAX_TRADE_LOG) {
+                list.pollLast();
+            }
+        }
+    }
+
+    // 최근 체결내역 조회
+    public List<TradeLogDto> findTradeLogs(String ticker) {
+        LinkedList<TradeLogDto> list = tradeLogCache.get(ticker);
+        if (list == null) return List.of();
+
+        synchronized (list) {
+            return List.copyOf(list);
+        }
+    }
+
+}


### PR DESCRIPTION
[OrderBookCache - 호가 캐시]
- CachedOrderBook 래퍼 객체 도입: 호가 데이터와 수신 시간(receivedAt)의 원자적 업데이트 보장
- computeIfPresent 활용: 조회-수정-저장 간의 Race Condition 원천 차단
- 변동호가(depth) 병합 로직 추가: 전체 덮어쓰기 문제 해결 및 30호가 전체 상태 유지
- Stale 방어 로직 적용: 네트워크 지연 시 과거 가격으로 체결되는 현상 방지
- findTop5() 추가: 프론트엔드 전송(SSE)을 위한 상위 5호가 추출 로직 분리

[StockPriceCache - 시세/체결 캐시]
- LinkedList + synchronized 블록 적용: 큐 사이즈 측정 및 삽입/삭제를 O(1) 성능으로 개선
- List.copyOf() 깊은 복사: ConcurrentModificationException 방지

[DirtyTracker - 변경 추적기]
- ConcurrentHashMap.newKeySet() 적용: 스레드 안전한 변경(Dirty) 종목 추적기 구현
- SSE 스케줄러가 변동이 발생한 종목만 효율적으로 브로드캐스팅할 수 있는 기반 마련