### PR TITLE
feat(crypto): 가상 스레드 기반 SSE 브로드캐스팅 및 1초 스냅샷 스케줄러 구현-#54

### DIFF
--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/scheduler/SnapshotScheduler.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/scheduler/SnapshotScheduler.java
@@ -1,0 +1,50 @@
+package site.tradelink.tradelink.cryptocurrency.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import site.tradelink.tradelink.cryptocurrency.inMemory.DirtyTracker;
+import site.tradelink.tradelink.cryptocurrency.inMemory.OrderBookCache;
+import site.tradelink.tradelink.cryptocurrency.inMemory.StockPriceCache;
+import site.tradelink.tradelink.cryptocurrency.sse.SseEmitterManager;
+
+import java.util.Set;
+
+/**
+ * 1초 스냅삿 스케줄러
+ * dirty 종목만 골라서 SSE broadcast
+ *
+ * 현재가: StockPriceCache 전체
+ * 호가: OrderBookCache.findTop5 (내부는 30호가 전체 보관. 전송 시에만 5단계로 자름
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SnapshotScheduler {
+
+    private final DirtyTracker dirtyTracker;
+    private final StockPriceCache priceCache;
+    private final OrderBookCache orderBookCache;
+    private final SseEmitterManager sseManager;
+
+    @Scheduled(fixedRate = 1000)
+    public void flush() {
+        Set<String> tickers = dirtyTracker.getAndClear();
+        if (tickers.isEmpty()) {
+            return;
+        }
+
+        for (String ticker : tickers) {
+            try {
+                priceCache.findPrice(ticker)
+                        .ifPresent(dto -> sseManager.broadcastPrice(ticker, dto));
+
+                orderBookCache.findTop5(ticker)
+                        .ifPresent(dto -> sseManager.broadcastOrderBook(ticker, dto));
+            } catch (Exception e) {
+                log.warn("[SnapshotScheduler] {} broadcast 실패: {}", ticker, e.getMessage());
+            }
+        }
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/sse/SseEmitterManager.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/sse/SseEmitterManager.java
@@ -1,12 +1,20 @@
 package site.tradelink.tradelink.cryptocurrency.sse;
 
 import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import site.tradelink.tradelink.cryptocurrency.dto.OrderBookDto;
+import site.tradelink.tradelink.cryptocurrency.dto.StockPriceSummaryDto;
+import site.tradelink.tradelink.cryptocurrency.dto.TradeLogDto;
+import site.tradelink.tradelink.cryptocurrency.inMemory.OrderBookCache;
+import site.tradelink.tradelink.cryptocurrency.inMemory.StockPriceCache;
 import site.tradelink.tradelink.cryptocurrency.sse.dto.SseEvent;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -18,6 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class SseEmitterManager {
 
     @Value("${sse.timeout:1800000}")
@@ -34,37 +43,107 @@ public class SseEmitterManager {
 
     private final ExecutorService senderPool = Executors.newVirtualThreadPerTaskExecutor();
 
+    private final StockPriceCache priceCache;
+    private final OrderBookCache orderBookCache;
+
     /**
-     * 연결
+     * 종목 상세 SSE 연결
+     * 연결 직후 현재가 + 호가 + 최근 체결 내역 캐시 스냅샷을 즉시 push
      */
-    public SseEmitter connect(String clientId) {
-        disconnect(clientId);
+    public SseEmitter connectTicker(String clientId, String ticker) {
+        String key = "T:" + ticker + ":" + clientId;
+        disconnect(key);
 
         SseEmitter emitter = new SseEmitter(timeout);
-        ClientEmitter client = new ClientEmitter(clientId, emitter, queueSize);
+        ClientEmitter client = new ClientEmitter(key, emitter, queueSize);
 
-        clients.put(clientId, client);
+        clients.put(key, client);
         connectionCount.incrementAndGet();
 
-        emitter.onCompletion(() -> disconnect(clientId));
-        emitter.onTimeout(() -> disconnect(clientId));
-        emitter.onError(e -> disconnect(clientId));
+        emitter.onCompletion(() -> disconnect(key));
+        emitter.onTimeout(() -> disconnect(key));
+        emitter.onError(e -> disconnect(key));
         
         startSenderLoop(client);
 
         // 연결 확인용 이벤트
         enqueue(client, "connect", "connected");
 
+        // 초기 데이터: 현재가
+        priceCache.findPrice(ticker)
+                .ifPresent(dto -> enqueue(client, "stock-price", dto));
+
+        // 초기 데이터: 호가창
+        orderBookCache.findTop5(ticker)
+                .ifPresent(dto -> enqueue(client, "order-book", dto));
+
+        // 초기 데이터: 최근 체결 내역
+        List<TradeLogDto> logs = priceCache.findTradeLogs(ticker);
+        if (!logs.isEmpty()) {
+            enqueue(client, "trade-log-init", logs);
+        }
+
+        return emitter;
+    }
+
+    /** 내 주문 알림 SSE 연결 */
+    public SseEmitter connectMember(Long memberSeq, String clientId) {
+        return connect("M:" + memberSeq + ":" + clientId);
+    }
+
+    private SseEmitter connect(String key) {
+        disconnect(key);
+
+        SseEmitter    emitter = new SseEmitter(timeout);
+        ClientEmitter client  = new ClientEmitter(key, emitter, queueSize);
+
+        clients.put(key, client);
+        connectionCount.incrementAndGet();
+
+        emitter.onCompletion(() -> disconnect(key));
+        emitter.onTimeout   (() -> disconnect(key));
+        emitter.onError     (e  -> disconnect(key));
+
+        startSenderLoop(client);
+
+        enqueue(client, "connect", "connected");
         return emitter;
     }
 
     /**
      * broadcast = 큐에만 적재
      */
-    public void broadcast(String eventName, Object data) {
-        clients.values().forEach(client -> {
-            if (!enqueue(client, eventName, data)) {
-                disconnect(client.clientId);
+
+    // SnapshotScheduler가 호출 - 1초 throttle 적용된 현재가
+    public void broadcastPrice(String ticker, StockPriceSummaryDto dto) {
+        broadcastToTicker(ticker, "stock-price", dto);
+    }
+
+    // SnapshotScheduler가 호출 - 1초 throttle 적용된 호가창
+    public void broadcastOrderBook(String ticker, OrderBookDto dto) {
+        broadcastToTicker(ticker, "order-book", dto);
+    }
+
+    // MatchingEngine이 직접 호출, 해당 멤버만
+    public void pushMyOrder(Long memberSeq, String ticker, long price,
+                            long quantity, String side, String status,
+                            LocalDateTime at) {
+
+        MyOrderDto dto = new MyOrderDto(ticker, price, quantity, side, status, at);
+        String prefix = "M:" + memberSeq + ":";
+
+        clients.forEach((key, client) -> {
+            if (key.startsWith(prefix)) enqueue(client, "my-order", dto);
+        });
+
+    }
+
+
+    public void broadcastToTicker(String ticker, String eventName, Object data) {
+        String prefix = "T:" + ticker + ":";
+        clients.forEach((key, client) -> {
+            if (key.startsWith(prefix)) {
+                if (!enqueue(client, eventName, data)) disconnect(key);
             }
         });
     }
@@ -128,11 +207,9 @@ public class SseEmitterManager {
                 try {
                     Thread.sleep(heartbeatInterval);
 
-                    if (clients.isEmpty()) {
-                        continue;
+                    if (!clients.isEmpty()) {
+                        clients.forEach((k, c) -> enqueue(c, "heartbeat", "ping"));
                     }
-
-                    broadcast("heartbeat", null);
 
                 } catch (InterruptedException ignored) {
                 } catch (Exception e) {


### PR DESCRIPTION
[SseEmitterManager - 실시간 스트리밍 엔진]
- 가상 스레드(Virtual Thread) 적용: 클라이언트별 전용 송신 스레드를 할당하여 I/O 블로킹 방지 및 대규모 커넥션 대응
- 클라이언트별 독립 Queue 도입: 네트워크 지연 발생 시 해당 클라이언트의 큐만 포화되도록 격리(장애 전파 방지)
- Backpressure 제어: 큐가 가득 찬 Slow Consumer는 즉시 연결을 종료하여 서버 메모리 누수 방지
- Poison Pill 패턴: 연결 종료 시 스레드가 안전하게 종료되도록 Graceful Shutdown 처리
- Heartbeat 스케줄러 추가: 30초 주기로 ping을 전송하여 브라우저/프록시 서버의 타임아웃 방지
- 초기 상태 동기화: 연결 직후 캐시(현재가, 호가, 체결내역) 스냅샷을 즉시 전송하여 화면 렌더링 지연 최소화

[SnapshotScheduler - 데이터 전송 최적화]
- 1초 단위 Throttling 적용: 초당 수백 번 바뀌는 호가를 1초 단위로 병합(Snapshot)하여 네트워크 트래픽 낭비 최소화
- DirtyTracker 연동: 상태가 실제로 변경된(Dirty) 종목만 골라내어 선택적으로 브로드캐스팅 수행