### PR TITLE
feat: 지갑(Wallet) 시스템 신규 구축 및 시장가 주문 파이프라인 연동-#58

### DIFF
--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/controller/StockAuthController.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/controller/StockAuthController.java
@@ -9,10 +9,15 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import site.tradelink.tradelink.cryptocurrency.dto.OrderRequestDto;
 import site.tradelink.tradelink.cryptocurrency.dto.TradeHistoryDto;
+import site.tradelink.tradelink.cryptocurrency.entity.Holding;
 import site.tradelink.tradelink.cryptocurrency.entity.OrderEvent;
+import site.tradelink.tradelink.cryptocurrency.enums.OrderSide;
 import site.tradelink.tradelink.cryptocurrency.inMemory.OrderBookCache;
+import site.tradelink.tradelink.cryptocurrency.repository.HoldingRepository;
 import site.tradelink.tradelink.cryptocurrency.repository.OrderEventRepository;
 import site.tradelink.tradelink.cryptocurrency.repository.TradeHistoryRepository;
+import site.tradelink.tradelink.cryptocurrency.service.OrderPlaceService;
+import site.tradelink.tradelink.cryptocurrency.service.WalletService;
 import site.tradelink.tradelink.cryptocurrency.sse.SseEmitterManager;
 import site.tradelink.tradelink.supports.request.ApiResponse;
 
@@ -24,8 +29,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class StockAuthController {
 
-    private final OrderBookCache orderBookCache;
-    private final OrderEventRepository orderEventRepository;
+    private final OrderPlaceService orderPlaceService;
     private final TradeHistoryRepository tradeHistoryRepository;
     private final SseEmitterManager sseManager;
 
@@ -34,24 +38,16 @@ public class StockAuthController {
     /**
      * 시장가 주문 접수
      * 1. 호가 존재 + stale 선검증
-     * 2. OrderEvent INSERT (Append-Only)
-     * 3. 202 Accepted 즉시 반환
+     * 2. 매수: bestPrice 기준 예약 차감 (슬리피지 대비)
+     * 3. OrderEvent INSERT (Append-Only)
+     * 4. 202 Accepted 즉시 반환
      */
     @PostMapping("/orders")
     public ResponseEntity<ApiResponse<Void>> placeOrder(
             @AuthenticationPrincipal Long memberSeq,
             @Valid @RequestBody OrderRequestDto req) {
 
-        // 호가 선검증 (stale 포함)
-        orderBookCache.getBestPrice(req.ticker(), req.side())
-                .orElseThrow(() -> new IllegalStateException(
-                        req.ticker() + " 호가 데이터를 수신 중입니다. 잠시 후 다시 시도해주세요."));
-
-        // OrderEvent INSERT
-        orderEventRepository.save(
-                OrderEvent.create(memberSeq, req.ticker(), req.side(), req.quantity())
-        );
-
+        orderPlaceService.place(memberSeq, req);
         return ResponseEntity.accepted().body(ApiResponse.ok(null));
     }
 

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/controller/WalletController.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/controller/WalletController.java
@@ -1,0 +1,79 @@
+package site.tradelink.tradelink.cryptocurrency.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import site.tradelink.tradelink.cryptocurrency.dto.TotalAssetDto;
+import site.tradelink.tradelink.cryptocurrency.dto.WalletDto;
+import site.tradelink.tradelink.cryptocurrency.entity.Holding;
+import site.tradelink.tradelink.cryptocurrency.entity.Wallet;
+import site.tradelink.tradelink.cryptocurrency.inMemory.StockPriceCache;
+import site.tradelink.tradelink.cryptocurrency.repository.HoldingRepository;
+import site.tradelink.tradelink.cryptocurrency.service.WalletService;
+import site.tradelink.tradelink.supports.request.ApiResponse;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/auth/wallet")
+@RequiredArgsConstructor
+public class WalletController {
+
+    private final WalletService walletService;
+    private final HoldingRepository holdingRepository;
+    private final StockPriceCache priceCache;
+
+    /**
+     * 지갑 조회 (현금 잔고)
+     */
+    @GetMapping
+    public ApiResponse<WalletDto> getWallet(@AuthenticationPrincipal Long memberSeq) {
+        Wallet wallet = walletService.getWallet(memberSeq);
+        return ApiResponse.ok(WalletDto.from(wallet));
+    }
+
+    /**
+     * 총 자산 조회
+     * 총 자산 = 현금(availableBalance) + 보유 종목 평가액 합계
+     */
+    @GetMapping("/total-asset")
+    public ApiResponse<TotalAssetDto> getTotalAsset(@AuthenticationPrincipal Long memberSeq) {
+        Wallet wallet = walletService.getWallet(memberSeq);
+        List<Holding> holdings = holdingRepository.findByMemberSeq(memberSeq);
+
+        // 보유 종목 평가액 계산
+        long holdingValue = holdings.stream()
+                .mapToLong(holding ->
+                        priceCache.findPrice(holding.getTicker())
+                                .map(price -> (long) (price.price() * holding.getQuantity()))
+                                .orElse(0L)
+                )
+                .sum();
+
+        long totalAsset = wallet.getBalance() + holdingValue;
+
+        return ApiResponse.ok(new TotalAssetDto(
+                wallet.getBalance(),
+                wallet.getAvailableBalance(),
+                holdingValue,
+                totalAsset
+        ));
+    }
+
+    /**
+     * 입금
+     * 최대 1억원 단위로 제한
+     */
+    @PostMapping("/deposit")
+    public ApiResponse<WalletDto> deposit(
+            @AuthenticationPrincipal Long memberSeq,
+            @RequestParam long amount) {
+
+        if (amount <= 0 || amount > 100_000_000L) {
+            throw new IllegalArgumentException("입금액은 1원 이상 1억원 이하만 가능합니다");
+        }
+
+        walletService.deposit(memberSeq, amount);
+        return ApiResponse.ok(WalletDto.from(walletService.getWallet(memberSeq)));
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/dto/TotalAssetDto.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/dto/TotalAssetDto.java
@@ -1,0 +1,9 @@
+package site.tradelink.tradelink.cryptocurrency.dto;
+
+public record TotalAssetDto(
+        Long balance,           // 현금 총 잔액
+        Long availableBalance,  // 주문 가능 금액
+        Long holdingValue,      // 보유 종목 평가액
+        Long totalAsset         // 총 자산 = balance + holdingValue
+) {
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/dto/WalletDto.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/dto/WalletDto.java
@@ -1,0 +1,12 @@
+package site.tradelink.tradelink.cryptocurrency.dto;
+
+import site.tradelink.tradelink.cryptocurrency.entity.Wallet;
+
+public record WalletDto(
+        Long balance,
+        Long availableBalance
+) {
+    public static WalletDto from(Wallet wallet) {
+        return new WalletDto(wallet.getBalance(), wallet.getAvailableBalance());
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/engine/MatchingEngine.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/engine/MatchingEngine.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import site.tradelink.tradelink.cryptocurrency.entity.OrderEvent;
 import site.tradelink.tradelink.cryptocurrency.enums.OrderSide;
 import site.tradelink.tradelink.cryptocurrency.inMemory.OrderBookCache;
+import site.tradelink.tradelink.cryptocurrency.service.WalletService;
 import site.tradelink.tradelink.cryptocurrency.sse.SseEmitterManager;
 
 import java.time.LocalDateTime;
@@ -22,6 +23,7 @@ public class MatchingEngine {
 
     private final OrderBookCache orderBookCache;
     private final StockTransactionService transactionService;
+    private final WalletService walletService;
     private final SseEmitterManager sseManger;
 
     public void execute(OrderEvent event) {
@@ -38,7 +40,29 @@ public class MatchingEngine {
         LocalDateTime now = LocalDateTime.now();
 
         // 2. DB 작업 (트랜잭션 범위 최소화)
-        transactionService.process(event, execPrice);
+        try {
+            transactionService.process(event, execPrice);
+        } catch (IllegalStateException e) {
+            log.warn("[Matching] 체결 실패 memberSeq={} ticker={}: {}",
+                    memberSeq, ticker, e.getMessage());
+
+            // 슬리피지 실패: 트랜잭션 밖에서 예약금 환불
+            // (트랜잭션 안에서 환불 시 예외로 인해 환불도 롤백되는 문제 방지)
+            if (OrderSide.BUY.equals(event.getSide()) && event.getReservedPrice() > 0) {
+                try {
+                    walletService.cancelReservation(memberSeq, event.getReservedPrice());
+                } catch (Exception ex) {
+                    log.error("[Matching] 예약금 환불 실패 memberSeq={}: {}", memberSeq, ex.getMessage());
+                }
+            }
+
+            try {
+                sseManger.pushMyOrder(memberSeq, ticker, execPrice, quantity, side, "FAILED", now);
+            } catch (Exception ex) {
+                log.warn("[Matching] SSE 실패 알림 전송 실패: {}", ex.getMessage());
+            }
+            throw e;
+        }
 
         // 3. SSE push (실패해도 클라이언트가 GET /orders로 폴백 가능)
         try {

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/engine/StockTransactionService.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/engine/StockTransactionService.java
@@ -2,6 +2,7 @@ package site.tradelink.tradelink.cryptocurrency.engine;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.tradelink.tradelink.cryptocurrency.entity.Holding;
@@ -11,6 +12,7 @@ import site.tradelink.tradelink.cryptocurrency.enums.OrderSide;
 import site.tradelink.tradelink.cryptocurrency.handler.CryptoName;
 import site.tradelink.tradelink.cryptocurrency.repository.HoldingRepository;
 import site.tradelink.tradelink.cryptocurrency.repository.TradeHistoryRepository;
+import site.tradelink.tradelink.cryptocurrency.service.WalletService;
 
 /**
  * 주식 체결 DB 트랜잭션 서비스
@@ -20,6 +22,8 @@ import site.tradelink.tradelink.cryptocurrency.repository.TradeHistoryRepository
 @Service
 @RequiredArgsConstructor
 public class StockTransactionService {
+
+    private final WalletService walletService;
 
     private final HoldingRepository holdingRepository;
     private final TradeHistoryRepository tradeHistoryRepository;
@@ -31,6 +35,7 @@ public class StockTransactionService {
         OrderSide side = event.getSide();
         Double quantity = event.getQuantity();
         Long memberSeq = event.getMemberSeq();
+        long execAmount = (long) (execPrice * quantity);
 
         // 매도: 보유 수량 검증 + 차감
         if (OrderSide.SELL == side) {
@@ -42,10 +47,13 @@ public class StockTransactionService {
             if (holding.getQuantity() == 0) {
                 holdingRepository.delete(holding);
             }
+            walletService.confirmSell(memberSeq, execAmount);
         }
 
         // 매수: Holding 평균가 갱신
         if (OrderSide.BUY == side) {
+            walletService.confirmBuy(memberSeq, event.getReservedPrice(), execAmount);
+
             Holding holding = holdingRepository.findByMemberSeqAndTicker(memberSeq, ticker)
                     .orElseGet(() -> Holding.create(memberSeq, ticker, CryptoName.of(ticker)));
 

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/entity/OrderEvent.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/entity/OrderEvent.java
@@ -33,12 +33,15 @@ public class OrderEvent extends BaseEntity {
 
     private Double quantity;
 
-    public static OrderEvent create(Long memberSeq, String ticker, OrderSide side, Double quantity) {
+    private Long reservedPrice;
+
+    public static OrderEvent create(Long memberSeq, String ticker, OrderSide side, Double quantity, Long reservedPrice) {
         return OrderEvent.builder()
                 .memberSeq(memberSeq)
                 .ticker(ticker)
-                .side(side) // 필요하면 검증 추가
+                .side(side)
                 .quantity(quantity)
+                .reservedPrice(reservedPrice)
                 .build();
     }
 }

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/entity/Wallet.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/entity/Wallet.java
@@ -1,0 +1,38 @@
+package site.tradelink.tradelink.cryptocurrency.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import site.tradelink.tradelink.supports.entity.BaseEntity;
+
+/**
+ * 모의투자 지감
+ */
+@Entity
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(
+        indexes = @Index(name = "idx_wallet_member", columnList = "memberSeq, availableBalance")
+)
+public class Wallet extends BaseEntity {
+
+    private static final long INITIAL_BALANCE = 200_000_000L; // 초기 시드머니 2억
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long seq;
+
+    private Long memberSeq;
+
+    private Long balance; // 총 잔액
+
+    private Long availableBalance;  // 주문 가능 금액
+
+    public static Wallet create(Long memberSeq) {
+        return Wallet.builder()
+                .memberSeq(memberSeq)
+                .balance(INITIAL_BALANCE)
+                .availableBalance(INITIAL_BALANCE)
+                .build();
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/repository/WalletRepository.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/repository/WalletRepository.java
@@ -1,0 +1,84 @@
+package site.tradelink.tradelink.cryptocurrency.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import site.tradelink.tradelink.cryptocurrency.entity.Wallet;
+
+import java.util.Optional;
+
+@Repository
+public interface WalletRepository extends JpaRepository<Wallet, Long> {
+
+    Optional<Wallet> findByMemberSeq(Long memberSeq);
+
+    /**
+     * 원자적 예약 차감
+     * DB 레벨에서 조회 + 검증 + 차감을 단일 쿼리로 처리
+     * available_balance > = amount 조건 불만족 시 0 반환 -> 잔고 부족
+     */
+    @Modifying
+    @Query("""
+            UPDATE Wallet w
+            SET w.availableBalance = w.availableBalance - :amount
+            WHERE w.memberSeq = :memberSeq
+              AND w.availableBalance >= :amount
+            """)
+    int reserve(@Param("memberSeq") Long memberSeq, @Param("amount") long amount);
+
+    /**
+     * 원자적 예약 취소 (주문 실패 시 환불)
+     */
+    @Modifying
+    @Query("""
+            UPDATE Wallet w
+            SET w.availableBalance = w.availableBalance + :amount
+            WHERE w.memberSeq = :memberSeq
+            """)
+    void cancelReservation(@Param("memberSeq") Long memberSeq, @Param("amount") long amount);
+
+    /**
+     * 원자적 매수 체결 확정
+     * balance 확정 차감 + 차액(refund) availableBalance 환불
+     * refund = reservedAmount - execAmount (더 싸게 체결된 경우 > 0)
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("""
+            UPDATE Wallet w
+            SET w.balance = w.balance - :execAmount,
+                w.availableBalance = w.availableBalance + :refund
+            WHERE w.memberSeq = :memberSeq
+            """)
+    void confirmBuy(@Param("memberSeq") Long memberSeq,
+                    @Param("execAmount") long execAmount,
+                    @Param("refund") long refund);
+
+
+    /**
+     * 원자적 매도 체결 확정
+     * balance + availableBalance 모두 증가
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("""
+            UPDATE Wallet w
+            SET w.balance = w.balance + :execAmount,
+                w.availableBalance = w.availableBalance + :execAmount
+            WHERE w.memberSeq = :memberSeq
+            """)
+    void confirmSell(@Param("memberSeq") Long memberSeq, @Param("execAmount") long execAmount);
+
+    /**
+     * 원자적 입금
+     */
+    @Modifying(clearAutomatically = true)
+    @Query("""
+            UPDATE Wallet w
+            SET w.balance = w.balance + :amount,
+                w.availableBalance = w.availableBalance + :amount
+            WHERE w.memberSeq = :memberSeq
+            """)
+    void deposit(@Param("memberSeq") Long memberSeq, @Param("amount") long amount);
+
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/scheduler/OrderEventProcessor.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/scheduler/OrderEventProcessor.java
@@ -1,9 +1,11 @@
-package site.tradelink.tradelink.cryptocurrency.engine;
+package site.tradelink.tradelink.cryptocurrency.scheduler;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import site.tradelink.tradelink.cryptocurrency.engine.MatchingEngine;
+import site.tradelink.tradelink.cryptocurrency.engine.ProcessorOffsetService;
 import site.tradelink.tradelink.cryptocurrency.entity.OrderEvent;
 import site.tradelink.tradelink.cryptocurrency.entity.ProcessorOffset;
 import site.tradelink.tradelink.cryptocurrency.repository.OrderEventRepository;
@@ -29,7 +31,7 @@ public class OrderEventProcessor {
 
     private final OrderEventRepository orderEventRepository;
     private final ProcessorOffsetRepository offsetRepository;
-    private final MatchingEngine            matchingEngine;
+    private final MatchingEngine matchingEngine;
     private final ProcessorOffsetService processorOffsetService;
 
     @Scheduled(fixedDelayString = "${scheduler.order.process-delay-ms:500}")

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/service/OrderPlaceService.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/service/OrderPlaceService.java
@@ -1,0 +1,47 @@
+package site.tradelink.tradelink.cryptocurrency.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.tradelink.tradelink.cryptocurrency.dto.OrderRequestDto;
+import site.tradelink.tradelink.cryptocurrency.entity.OrderEvent;
+import site.tradelink.tradelink.cryptocurrency.enums.OrderSide;
+import site.tradelink.tradelink.cryptocurrency.inMemory.OrderBookCache;
+import site.tradelink.tradelink.cryptocurrency.repository.OrderEventRepository;
+
+/**
+ * 주문 접수 퍼사드 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OrderPlaceService {
+
+    private final OrderBookCache orderBookCache;
+    private final WalletService        walletService;
+    private final OrderEventRepository orderEventRepository;
+
+    @Transactional
+    public void place(Long memberSeq, OrderRequestDto req) {
+
+        // 1. 호가 선검증 (stale 포함)
+        long bestPrice = orderBookCache.getBestPrice(req.ticker(), req.side())
+                .orElseThrow(() -> new IllegalStateException(
+                        req.ticker() + " 호가 데이터를 수신 중입니다. 잠시 후 다시 시도해주세요."));
+
+        // 2. 매수: 예약 차감 (availableBalance)
+        long reservedAmount = 0L;
+        if (OrderSide.BUY == req.side()) {
+            reservedAmount = (long) (bestPrice * req.quantity());
+            walletService.reserve(memberSeq, reservedAmount);
+        }
+
+        // 3. OrderEvent INSERT
+        // reserve() 와 같은 트랜잭션 → save() 실패 시 reserve()도 롤백
+        orderEventRepository.save(
+                OrderEvent.create(memberSeq, req.ticker(), req.side(),
+                        req.quantity(), reservedAmount)
+        );
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/service/WalletService.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/cryptocurrency/service/WalletService.java
@@ -1,0 +1,68 @@
+package site.tradelink.tradelink.cryptocurrency.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.tradelink.tradelink.cryptocurrency.entity.Wallet;
+import site.tradelink.tradelink.cryptocurrency.repository.WalletRepository;
+
+/**
+ * 지갑 서비스
+ * 예약 차감: WalletRepository.reserve() 원자적 UPDATE 쿼리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WalletService {
+
+    private final WalletRepository walletRepository;
+
+    // 예약 차감 (placeOrder 시점)
+    @Transactional
+    public void reserve(Long memberSeq, long amount) {
+        int updated = walletRepository.reserve(memberSeq, amount);
+        if (updated == 0) {
+            throw new IllegalStateException(
+                    "주문 가능 금액이 부족합니다. (요청=" + amount + "원)");
+        }
+    }
+
+    // 예약 취소
+    @Transactional
+    public void cancelReservation(Long memberSeq, long amount) {
+        walletRepository.cancelReservation(memberSeq, amount);
+    }
+
+    // 체결 확정 (MatchingEngine 시점)
+    @Transactional
+    public void confirmBuy(Long memberSeq, long reservedAmount, long execAmount) {
+        if (execAmount > reservedAmount) {
+            throw new IllegalStateException(
+                    "체결가 상승으로 잔고 부족 (예약=" + reservedAmount + ", 체결=" + execAmount + ")");
+        }
+        long refund = reservedAmount - execAmount;
+        walletRepository.confirmBuy(memberSeq, execAmount, refund);
+    }
+
+    @Transactional
+    public void confirmSell(Long memberSeq, long execAmount) {
+        walletRepository.confirmSell(memberSeq, execAmount);
+    }
+
+    // 입금
+    @Transactional
+    public void deposit(Long memberSeq, long amount) {
+        if (amount <= 0 || amount > 100_000_000L) {
+            throw new IllegalArgumentException("입금액은 1원 이상 1억원 이하만 가능합니다");
+        }
+        walletRepository.deposit(memberSeq, amount);
+    }
+
+    // 조회
+    @Transactional(readOnly = true)
+    public Wallet getWallet(Long memberSeq) {
+        return walletRepository.findByMemberSeq(memberSeq)
+                .orElseThrow(() -> new IllegalStateException("지갑 없음: " + memberSeq));
+    }
+}

--- a/tradelink/src/main/java/site/tradelink/tradelink/oauth2/service/MemberService.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/oauth2/service/MemberService.java
@@ -3,6 +3,8 @@ package site.tradelink.tradelink.oauth2.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import site.tradelink.tradelink.cryptocurrency.entity.Wallet;
+import site.tradelink.tradelink.cryptocurrency.repository.WalletRepository;
 import site.tradelink.tradelink.oauth2.dto.ProviderUser;
 import site.tradelink.tradelink.oauth2.entity.Member;
 import site.tradelink.tradelink.oauth2.repository.MemberRepository;
@@ -13,7 +15,11 @@ import site.tradelink.tradelink.oauth2.repository.MemberRepository;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final WalletRepository walletRepository;
 
+    /**
+     * 신규 회원 등록 Member 저장 후 Wallet 자동 생성 (초기 시드머니 2억) 같은 트랜잭션 안에서 처리
+     */
     public Member register(ProviderUser providerUser) {
         Member member = Member.builder()
                 .memberId(providerUser.getId())
@@ -22,6 +28,10 @@ public class MemberService {
                 .email(providerUser.getEmail())
                 .build();
 
-        return memberRepository.save(member);
+        Member saved = memberRepository.save(member);
+
+        walletRepository.save(Wallet.create(saved.getSeq()));
+
+        return saved;
     }
 }


### PR DESCRIPTION
- Wallet 신규 추가 및 초기 시드머니 설정 로직 구현
- WalletController 및 WalletService 추가 (지갑 조회, 총 자산 계산, 입금 기능)
- WalletRepository: 동시성 이슈 방지를 위한 원자적(Atomic) UPDATE 쿼리 작성 (주문 예약, 체결 확정, 환불)
- OrderPlaceService 도입: 주문 접수 시 지갑 잔고 예약 차감을 단일 트랜잭션으로 묶어 데이터 정합성 보장
- MatchingEngine 로직 개선: 체결 및 예외(슬리피지 등) 발생 시 트랜잭션 외부에서 안전하게 예약금 환불 처리되도록 연동
- OrderEvent 엔티티에 reservedPrice 필드를 추가하여 비동기 정산 시 데이터 무결성 확보