### PR TITLE
fix: 환율 조회 시 당일 데이터 없을 경우 예외 발생 문제 수정-#64

### DIFF
--- a/tradelink/src/main/java/site/tradelink/tradelink/TradelinkApplication.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/TradelinkApplication.java
@@ -2,6 +2,7 @@ package site.tradelink.tradelink;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -9,6 +10,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling // 스케줄링 활성화
 @EnableAsync // 비동기 처리 활성화
 @EnableRetry // 재시도 기능 활성화
+@EnableJpaAuditing
 @SpringBootApplication
 public class TradelinkApplication {
 

--- a/tradelink/src/main/java/site/tradelink/tradelink/exchangeRate/authorization/scheduler/BokApiClient.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/exchangeRate/authorization/scheduler/BokApiClient.java
@@ -24,6 +24,7 @@ public class BokApiClient {
 
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
 
+    private static final int MAX_FALLBACK_DAYS = 7;
     private final RestClient bokRestClient;
     private final BokApiResponseValidator validator;
 
@@ -31,21 +32,48 @@ public class BokApiClient {
     private String authKey;
 
     /**
-     * 최신 환율 조회 (당일)
+     * 최신 환율 조회
+     * 당일 데이터 없으면 최대 7일 전까지 폴백
      */
     public BokApiExchangeRateDto.Row getLatestExchangeRate(Currency currency) {
         LocalDate today = LocalDate.now();
-        
-        BokApiExchangeRateDto.BokApiExchangeRateResponse response = fetchData(
-                StatisticCode.EXCHANGE_RATE,
-                currency.getItemCode(),
-                today,
-                today
+
+        for (int i = 0; i <= MAX_FALLBACK_DAYS; i++) {
+            LocalDate targetDate = today.minusDays(i);
+
+            BokApiExchangeRateDto.BokApiExchangeRateResponse response = fetchData(
+                    StatisticCode.EXCHANGE_RATE,
+                    currency.getItemCode(),
+                    targetDate,
+                    targetDate
+            );
+
+            if (hasData(response)) {
+                if (i > 0) {
+                    log.info("[BOK] {} 당일 데이터 없음 → {}일 전({}) 데이터 사용",
+                            currency.name(), i, targetDate);
+                }
+                validator.validate(response);
+                return response.getStatisticSearch().getRows().getFirst();
+            }
+        }
+
+        // 7일 이내 데이터가 전혀 없는 경우 (거의 발생하지 않음)
+        throw new RuntimeException(
+                "[BOK] " + currency.name() + " 최근 " + MAX_FALLBACK_DAYS + "일 이내 데이터 없음"
         );
+    }
 
-        validator.validate(response);
-
-        return response.getStatisticSearch().getRows().getFirst();
+    /**
+     * 응답에 실제 데이터가 있는지 확인
+     */
+    private boolean hasData(BokApiExchangeRateDto.BokApiExchangeRateResponse response) {
+        return response != null
+                && response.getStatisticSearch() != null
+                && response.getStatisticSearch().getRows() != null
+                && !response.getStatisticSearch().getRows().isEmpty()
+                && response.getStatisticSearch().getRows().getFirst().getDataValue() != null
+                && !response.getStatisticSearch().getRows().getFirst().getDataValue().isBlank();
     }
 
     /**

--- a/tradelink/src/main/java/site/tradelink/tradelink/exchangeRate/authorization/scheduler/ExchangeRateScheduler.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/exchangeRate/authorization/scheduler/ExchangeRateScheduler.java
@@ -25,7 +25,7 @@ public class ExchangeRateScheduler {
     /**
      * 환율 업데이트
      */
-    @Scheduled(cron = "${scheduler.exchange-rate.update-cron:0 */10 * * * MON-FRI}")
+    @Scheduled(cron = "${scheduler.exchange-rate.update-cron:*/10 * * * * MON-FRI}")
     public void updateExchangeRate() {
         try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
             for (Currency currency : Currency.values()) {

--- a/tradelink/src/main/java/site/tradelink/tradelink/exchangeRate/authorization/scheduler/enums/Currency.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/exchangeRate/authorization/scheduler/enums/Currency.java
@@ -11,20 +11,21 @@ import lombok.RequiredArgsConstructor;
 public enum Currency {
 
     // 미국 달러
-    USD("0000001", "미국 달러"),
+    USD("0000001", "미국 달러", "USD"),
 
     // 일본 엔
-    JPY("0000002", "일본 엔화"),
+    JPY("0000002", "일본 엔화", "JPY"),
 
     // 유로
-    EUR("0000003", "유로"),
+    EUR("0000003", "유로", "EUR"),
 
     // 영국 파운드
-    GBP("0000012", "영국 파운드"),
+    GBP("0000012", "영국 파운드", "GBP"),
 
     // 중국 위안
-    CNY("0000053", "중국 위안화");
+    CNY("0000053", "중국 위안화", "CNY");
 
     private final String itemCode; // 한국은행 API ITEM_CODE1
     private final String koreanName; // 한글명
+    private final String currencyCode;
 }

--- a/tradelink/src/main/java/site/tradelink/tradelink/exchangeRate/service/ExchangeRateDataService.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/exchangeRate/service/ExchangeRateDataService.java
@@ -46,14 +46,14 @@ public class ExchangeRateDataService {
      * CurrentExchangeRate 업데이트
      */
     private CurrentExchangeRate updateCurrentRate(Currency currency, Double rate, LocalDateTime dateTime) {
-        Optional<CurrentExchangeRate> optional = currentRepository.findByCurrencyCode(currency.getItemCode());
+        Optional<CurrentExchangeRate> optional = currentRepository.findByCurrencyCode(currency.getCurrencyCode());
 
         CurrentExchangeRate current;
         Double previous = null;
 
         if (optional.isEmpty()) {
             current = CurrentExchangeRate.builder()
-                    .currencyCode(currency.getItemCode())
+                    .currencyCode(currency.getCurrencyCode())
                     .currencyName(currency.getKoreanName())
                     .rate(rate)
                     .baseDateTime(dateTime)
@@ -76,7 +76,7 @@ public class ExchangeRateDataService {
      */
     private void saveHistory(Currency currency, Double rate, LocalDateTime dateTime) {
         ExchangeRate history = ExchangeRate.builder()
-                .currencyCode(currency.getItemCode())
+                .currencyCode(currency.getCurrencyCode())
                 .rate(rate)
                 .baseDateTime(dateTime)
                 .build();

--- a/tradelink/src/main/java/site/tradelink/tradelink/exchangeRate/service/ExchangeRateService.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/exchangeRate/service/ExchangeRateService.java
@@ -91,10 +91,15 @@ public class ExchangeRateService {
     }
 
     private int parsePeriod(String period) {
-        try {
-            return Integer.parseInt(period);
-        } catch (NumberFormatException e) {
-            return 1; // 기본값 당일 조회
-        }
+        if (period == null) return 1;
+        return switch (period.toUpperCase()) {
+            case "1D" -> 1;
+            case "1W" -> 7;
+            case "1M" -> 30;
+            case "3M" -> 90;
+            case "6M" -> 180;
+            case "1Y" -> 365;
+            default -> 1;
+        };
     }
 }

--- a/tradelink/src/main/java/site/tradelink/tradelink/oauth2/config/OAuth2ClientConfig.java
+++ b/tradelink/src/main/java/site/tradelink/tradelink/oauth2/config/OAuth2ClientConfig.java
@@ -1,5 +1,8 @@
 package site.tradelink.tradelink.oauth2.config;
 
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.security.autoconfigure.web.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
@@ -10,7 +13,9 @@ import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequest
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.expression.WebExpressionAuthorizationManager;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfToken;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.web.filter.OncePerRequestFilter;
 import site.tradelink.tradelink.oauth2.service.CustomOAuth2UserService;
 import site.tradelink.tradelink.oauth2.service.CustomOidcUserService;
 
@@ -30,6 +35,20 @@ public class OAuth2ClientConfig {
                 .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
                 .csrfTokenRequestHandler(new CsrfTokenRequestAttributeHandler())
         );
+
+        http.addFilterAfter(new OncePerRequestFilter() {
+            @Override
+            protected void doFilterInternal(HttpServletRequest request,
+                                            HttpServletResponse response,
+                                            FilterChain filterChain)
+                    throws jakarta.servlet.ServletException, java.io.IOException {
+                CsrfToken csrfToken = (CsrfToken) request.getAttribute(CsrfToken.class.getName());
+                if (csrfToken != null) {
+                    csrfToken.getToken(); // 쿠키 세팅 트리거
+                }
+                filterChain.doFilter(request, response);
+            }
+        }, org.springframework.security.web.csrf.CsrfFilter.class);
 
         http.authorizeHttpRequests(auth -> auth
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()


### PR DESCRIPTION
- 환율 DTO 필드 수정
- 당일 데이터 없을 경우 최대 7일 이전 데이터 조회하도록 fallback 로직 추가