### PR TITLE
fix: CSRF 쿠키 도메인을 .gomets.store로 설정-#80

### DIFF
--- a/backend/src/main/java/site/tradelink/tradelink/oauth2/config/OAuth2ClientConfig.java
+++ b/backend/src/main/java/site/tradelink/tradelink/oauth2/config/OAuth2ClientConfig.java
@@ -38,6 +38,7 @@ public class OAuth2ClientConfig {
                 cookie.sameSite("None")
                         .secure(true)
                         .path("/")
+                        .domain(".gomets.store")
                 );
 
         http.csrf(csrf -> csrf


### PR DESCRIPTION
- server.gomets.store에만 저장되던 XSRF-TOKEN 쿠키를 www.gomets.store에서도 읽을 수 있도록 도메인 수정