### PR TITLE
feat: 서버 재시작 시 누락된 종가 자동 복구 기능 추가-#83

### DIFF
--- a/backend/src/main/java/site/tradelink/tradelink/exchangeRate/authorization/recovery/DailyCloseRecovery.java
+++ b/backend/src/main/java/site/tradelink/tradelink/exchangeRate/authorization/recovery/DailyCloseRecovery.java
@@ -1,0 +1,56 @@
+package site.tradelink.tradelink.exchangeRate.authorization.recovery;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import site.tradelink.tradelink.exchangeRate.authorization.scheduler.enums.Currency;
+import site.tradelink.tradelink.exchangeRate.repository.DailyExchangeRateRepository;
+import site.tradelink.tradelink.exchangeRate.repository.ExchangeRateRepository;
+import site.tradelink.tradelink.exchangeRate.service.ExchangeRateDataService;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DailyCloseRecovery implements ApplicationRunner {
+
+    private final ExchangeRateDataService dataService;
+    private final DailyExchangeRateRepository dailyRepository;
+    private final ExchangeRateRepository historyRepository;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        LocalDateTime start = yesterday.atStartOfDay();
+        LocalDateTime end = yesterday.atTime(23, 59, 59);
+
+        // 주말/공휴일 체크 - 어떤 통화든 하나라도 있으면 영업일로 판단
+        boolean hasYesterdayData = Arrays.stream(Currency.values())
+                .anyMatch(currency ->
+                        historyRepository.existsByCurrencyCodeAndBaseDateTimeBetween(
+                                currency.getCurrencyCode(), start, end)
+                );
+
+        if (!hasYesterdayData) {
+            log.info("어제({}) 환율 데이터 없음 (휴일 추정) → 복구 스킵", yesterday);
+            return;
+        }
+
+        // 종가 누락 체크 - 하나라도 없으면 복구 실행
+        boolean allExists = Arrays.stream(Currency.values())
+                .allMatch(currency ->
+                        dailyRepository.existsByCurrencyCodeAndBaseDate(
+                                currency.getCurrencyCode(), yesterday)
+                );
+
+        if (!allExists) {
+            log.info("어제({}) 종가 누락 감지 → 자동 복구 실행", yesterday);
+            dataService.recoverDailyClosingRates(yesterday);
+        }
+    }
+}

--- a/backend/src/main/java/site/tradelink/tradelink/exchangeRate/authorization/scheduler/ExchangeRateScheduler.java
+++ b/backend/src/main/java/site/tradelink/tradelink/exchangeRate/authorization/scheduler/ExchangeRateScheduler.java
@@ -25,7 +25,7 @@ public class ExchangeRateScheduler {
     /**
      * 환율 업데이트
      */
-    @Scheduled(cron = "${scheduler.exchange-rate.update-cron:0 * * * * MON-FRI}")
+    @Scheduled(cron = "${scheduler.exchange-rate.update-cron:0 0 * * * MON-FRI}")
     public void updateExchangeRate() {
         try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
             for (Currency currency : Currency.values()) {

--- a/backend/src/main/java/site/tradelink/tradelink/exchangeRate/repository/DailyExchangeRateRepository.java
+++ b/backend/src/main/java/site/tradelink/tradelink/exchangeRate/repository/DailyExchangeRateRepository.java
@@ -4,7 +4,12 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import site.tradelink.tradelink.exchangeRate.entity.DailyExchangeRate;
 
+import java.time.LocalDate;
+import java.util.Optional;
+
 @Repository
 public interface DailyExchangeRateRepository extends JpaRepository<DailyExchangeRate, Long>, DailyExchangeRateCustomRepository {
+    boolean existsByCurrencyCodeAndBaseDate(String currencyCode, LocalDate baseDate);
 
+    Optional<DailyExchangeRate> findByCurrencyCodeAndBaseDate(String currencyCode, LocalDate baseDate);
 }

--- a/backend/src/main/java/site/tradelink/tradelink/exchangeRate/repository/ExchangeRateRepository.java
+++ b/backend/src/main/java/site/tradelink/tradelink/exchangeRate/repository/ExchangeRateRepository.java
@@ -4,7 +4,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import site.tradelink.tradelink.exchangeRate.entity.ExchangeRate;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+
 @Repository
 public interface ExchangeRateRepository extends JpaRepository<ExchangeRate, Long>, ExchangeRateCustomRepository {
+    boolean existsByCurrencyCodeAndBaseDateTimeBetween(
+            String currencyCode, LocalDateTime start, LocalDateTime end);
 
+    Optional<ExchangeRate> findTopByCurrencyCodeAndBaseDateTimeBetweenOrderByBaseDateTimeDesc(
+            String currencyCode, LocalDateTime start, LocalDateTime end);
 }

--- a/backend/src/main/java/site/tradelink/tradelink/exchangeRate/service/ExchangeRateDataService.java
+++ b/backend/src/main/java/site/tradelink/tradelink/exchangeRate/service/ExchangeRateDataService.java
@@ -14,6 +14,7 @@ import site.tradelink.tradelink.exchangeRate.repository.ExchangeRateRepository;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -101,5 +102,39 @@ public class ExchangeRateDataService {
                 // 이미 저장된 데이터 무시
             }
         }
+    }
+
+    // 복구용 - 특정 날짜 히스토리 기반으로 종가 저장
+    @Transactional
+    public void recoverDailyClosingRates(LocalDate date) {
+        LocalDateTime start = date.atStartOfDay();
+        LocalDateTime end = date.atTime(23, 59, 59);
+
+        Arrays.stream(Currency.values()).forEach(currency -> {
+            historyRepository
+                    .findTopByCurrencyCodeAndBaseDateTimeBetweenOrderByBaseDateTimeDesc(
+                            currency.getCurrencyCode(), start, end)
+                    .ifPresent(history -> {
+                        DailyExchangeRate prevDay = dailyRepository
+                                .findByCurrencyCodeAndBaseDate(currency.getCurrencyCode(), date.minusDays(1))
+                                .orElse(null);
+
+                        Double changeAmount = prevDay != null ? history.getRate() - prevDay.getRate() : null;
+                        Double changePercent = prevDay != null ? (changeAmount / prevDay.getRate()) * 100 : null;
+
+                        DailyExchangeRate daily = DailyExchangeRate.builder()
+                                .currencyCode(history.getCurrencyCode())
+                                .currencyName(currency.getKoreanName())
+                                .rate(history.getRate())
+                                .changeAmount(changeAmount)
+                                .changePercent(changePercent)
+                                .baseDate(date)
+                                .build();
+                        try {
+                            dailyRepository.save(daily);
+                        } catch (DataIntegrityViolationException ignored) {
+                        }
+                    });
+        });
     }
 }


### PR DESCRIPTION
- DailyCloseRecovery: 서버 시작 시 어제 종가 누락 감지 후 복구
- Currency 순회하여 영업일 여부 및 누락 여부 판단
- 주말/공휴일은 히스토리 데이터 없으면 복구 스킵
- ExchangeRateDataService: recoverDailyClosingRates 추가 (히스토리 기반 복구)
- ExchangeRateRepository: existsByCurrencyCodeAndBaseDateTimeBetween, findTopBy... 추가
- DailyExchangeRateRepository: existsByCurrencyCodeAndBaseDate, findByCurrencyCodeAndBaseDate 추가