### PR TITLE
fix: 비로그인 사용자 게시글 조회 시 발생하는 좋아요 상태 조회 에러(NPE) 수정-#86

### DIFF
--- a/backend/src/main/java/site/tradelink/tradelink/like/controller/LikeController.java
+++ b/backend/src/main/java/site/tradelink/tradelink/like/controller/LikeController.java
@@ -23,7 +23,9 @@ public class LikeController {
      */
     @GetMapping("/posts/{postSeq}")
     public ApiResponse<LikeStatusResponseDto> getLikeStatus(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, @PathVariable Long postSeq) {
-        Long memberSeq = customOAuth2User.getMemberSeq();
+
+        Long memberSeq = (customOAuth2User != null) ? customOAuth2User.getMemberSeq() : null;
+
         LikeStatusResponseDto response = likeQueryService.getLikeStatus(memberSeq, postSeq);
         return ApiResponse.ok(response);
     }


### PR DESCRIPTION
- LikeController: CustomOAuth2User가 null일 경우 memberSeq를 null로 안전하게 전달하도록 수정